### PR TITLE
Fix incorrect pending invites count

### DIFF
--- a/frontend/client/components/CreateFlow/Review.tsx
+++ b/frontend/client/components/CreateFlow/Review.tsx
@@ -196,19 +196,22 @@ const ReviewMilestones = ({
 const ReviewTeam: React.SFC<{
   team: ProposalDraft['team'];
   invites: ProposalDraft['invites'];
-}> = ({ team, invites }) => (
-  <div className="ReviewTeam">
-    {team.map((u, idx) => (
-      <div className="ReviewTeam-member" key={idx}>
-        <UserAvatar className="ReviewTeam-member-avatar" user={u} />
-        <div className="ReviewTeam-member-info">
-          <div className="ReviewTeam-member-info-name">{u.displayName}</div>
-          <div className="ReviewTeam-member-info-title">{u.title}</div>
+}> = ({ team, invites }) => {
+  const pendingInvites = invites.filter(inv => inv.accepted === null).length;
+  return (
+    <div className="ReviewTeam">
+      {team.map((u, idx) => (
+        <div className="ReviewTeam-member" key={idx}>
+          <UserAvatar className="ReviewTeam-member-avatar" user={u} />
+          <div className="ReviewTeam-member-info">
+            <div className="ReviewTeam-member-info-name">{u.displayName}</div>
+            <div className="ReviewTeam-member-info-title">{u.title}</div>
+          </div>
         </div>
-      </div>
-    ))}
-    {!!invites.filter(inv => inv.accepted === null).length && (
-      <div className="ReviewTeam-invites">+ {invites.length} invite(s) pending</div>
-    )}
-  </div>
-);
+      ))}
+      {!!pendingInvites && (
+        <div className="ReviewTeam-invites">+ {pendingInvites} invite(s) pending</div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
Closes #65. Fixes the invite count including accepted and rejected invites. To test, invite two people, accept with one, and go to review to confirm the count is correct.