### PR TITLE
Fade auth in, invisible while checking.

### DIFF
--- a/frontend/client/components/Header/Auth.less
+++ b/frontend/client/components/Header/Auth.less
@@ -1,16 +1,8 @@
 .AuthButton {
-  // Needed to override inherited styles
-  &.Header-links-link {
-    display: flex;
-    align-items: center;
-    margin-right: -0.2rem;
-    transform: none;
-    transition: opacity 200ms ease, transform 200ms ease;
+  transition: opacity 200ms ease;
 
-    &.is-loading {
-      opacity: 0;
-      transform: scale(0.9);
-    }
+  &.is-loading {
+    opacity: 0;
   }
 
   &:hover {
@@ -60,5 +52,12 @@
         opacity: 0.8;
       }
     }
+  }
+
+  // Override inherited link styles
+  .Header-links-link {
+    display: flex;
+    align-items: center;
+    margin-right: -0.2rem;
   }
 }

--- a/frontend/client/components/Header/Auth.tsx
+++ b/frontend/client/components/Header/Auth.tsx
@@ -10,6 +10,7 @@ import './Auth.less';
 interface StateProps {
   user: AppState['auth']['user'];
   isAuthingUser: AppState['auth']['isAuthingUser'];
+  isCheckingUser: AppState['auth']['isCheckingUser'];
 }
 
 type Props = StateProps;
@@ -24,7 +25,7 @@ class HeaderAuth extends React.Component<Props> {
   };
 
   render() {
-    const { user, isAuthingUser } = this.props;
+    const { user, isAuthingUser, isCheckingUser } = this.props;
     const { isMenuOpen } = this.state;
     const isAuthed = !!user;
 
@@ -32,15 +33,14 @@ class HeaderAuth extends React.Component<Props> {
     let isLoading;
     if (user) {
       avatar = <UserAvatar user={user} />;
-    } else if (isAuthingUser) {
-      avatar = '';
+    } else if (isAuthingUser || isCheckingUser) {
       isLoading = true;
     }
 
     const link = (
       <Link
         to={isAuthed ? '/profile' : '/auth'}
-        className={classnames('AuthButton Header-links-link', isLoading && 'is-loading')}
+        className="Header-links-link"
         onClick={this.toggleMenu}
       >
         {isAuthed ? '' : 'Sign in'}
@@ -57,36 +57,42 @@ class HeaderAuth extends React.Component<Props> {
       </Link>
     );
 
-    // If they're not authed, don't render the dropdown menu
-    if (!isAuthed) {
-      return link;
+    let content;
+    if (isAuthed) {
+      const menu = (
+        <Menu style={{ minWidth: '100px' }} onClick={this.closeMenu}>
+          <Menu.Item>
+            <Link to="/profile">Profile</Link>
+          </Menu.Item>
+          <Menu.Item>
+            <Link to="/profile/settings">Settings</Link>
+          </Menu.Item>
+          <Menu.Divider />
+          <Menu.Item>
+            <Link to="/auth/sign-out">Sign out</Link>
+          </Menu.Item>
+        </Menu>
+      );
+      content = (
+        <Dropdown
+          overlay={menu}
+          visible={isMenuOpen}
+          placement="bottomRight"
+          onVisibleChange={this.handleVisibilityChange}
+          trigger={['click']}
+        >
+          {link}
+        </Dropdown>
+      )
+    }
+    else {
+      content = link;
     }
 
-    const menu = (
-      <Menu style={{ minWidth: '100px' }} onClick={this.closeMenu}>
-        <Menu.Item>
-          <Link to="/profile">Profile</Link>
-        </Menu.Item>
-        <Menu.Item>
-          <Link to="/profile/settings">Settings</Link>
-        </Menu.Item>
-        <Menu.Divider />
-        <Menu.Item>
-          <Link to="/auth/sign-out">Sign out</Link>
-        </Menu.Item>
-      </Menu>
-    );
-
     return (
-      <Dropdown
-        overlay={menu}
-        visible={isMenuOpen}
-        placement="bottomRight"
-        onVisibleChange={this.handleVisibilityChange}
-        trigger={['click']}
-      >
-        {link}
-      </Dropdown>
+      <div className={classnames('AuthButton', isLoading && 'is-loading')}>
+        {content}
+      </div>
     );
   }
 
@@ -113,4 +119,5 @@ class HeaderAuth extends React.Component<Props> {
 export default connect<StateProps, {}, {}, AppState>(state => ({
   user: state.auth.user,
   isAuthingUser: state.auth.isAuthingUser,
+  isCheckingUser: state.auth.isCheckingUser,
 }))(HeaderAuth);


### PR DESCRIPTION
Closes #59. Fixes the flash of "Sign in" by using the correct prop, and changing the way the render function works to not insert a new node.

If you want to test this, you have to add an artificial sleep to /me in `backend/grant/user/views.py` because it takes longer for the CSS to load than for the endpoint to return (Which is why this issue wasn't caught in dev.)
```diff
 from flask_yoloapi import endpoint, parameter
+from time import sleep

 def get_me():
+    sleep(2)