### PR TITLE
Link to specific tabs from query param

### DIFF
--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -302,7 +302,8 @@ def post_proposal_team_invite(proposal_id, address):
             'user': user,
             'inviter': g.current_user,
             'proposal': g.current_proposal,
-            'invite_url': make_url(f'/profile/{user.id}' if user else '/auth')
+            'invite_url': make_url(
+                f'/profile/{user.id}?tab=invitations' if user else '/auth')
         })
 
     return proposal_team_invite_schema.dump(invite), 201

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -303,7 +303,7 @@ def post_proposal_team_invite(proposal_id, address):
             'inviter': g.current_user,
             'proposal': g.current_proposal,
             'invite_url': make_url(
-                f'/profile/{user.id}?tab=invitations' if user else '/auth')
+                f'/profile/{user.id}?tab=invites' if user else '/auth')
         })
 
     return proposal_team_invite_schema.dump(invite), 201

--- a/frontend/client/components/AuthRoute.tsx
+++ b/frontend/client/components/AuthRoute.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Route, Redirect, RouteProps } from 'react-router-dom';
+import { Spin } from 'antd';
 import { AppState } from 'store/reducers';
 
 interface StateProps {
   user: AppState['auth']['user'];
+  isCheckingUser: AppState['auth']['isCheckingUser'];
 }
 
 interface OwnProps {
@@ -15,17 +17,22 @@ type Props = RouteProps & StateProps & OwnProps;
 
 class AuthRoute extends React.Component<Props> {
   public render() {
-    const { user, onlyLoggedOut, ...routeProps } = this.props;
+    const { user, onlyLoggedOut, isCheckingUser, location, ...routeProps } = this.props;
+    if (isCheckingUser) {
+      return <Spin />;
+    }
     if ((user && !onlyLoggedOut) || (!user && onlyLoggedOut)) {
       return <Route {...routeProps} />;
     } else {
       // TODO: redirect to desired destination after auth
       // TODO: Show alert that claims they need to be logged in
-      return <Redirect to={onlyLoggedOut ? '/profile' : '/auth'} />;
+      const pathname = onlyLoggedOut ? '/profile' : '/auth';
+      return <Redirect to={{ ...location, pathname }} />;
     }
   }
 }
 
 export default connect((state: AppState) => ({
   user: state.auth.user,
+  isCheckingUser: state.auth.isCheckingUser,
 }))(AuthRoute);

--- a/frontend/client/components/ContributionModal/index.tsx
+++ b/frontend/client/components/ContributionModal/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Modal } from 'antd';
 import Result from 'ant-design-pro/lib/Result';
 import { postProposalContribution, getProposalContribution } from 'api/api';
@@ -56,7 +57,8 @@ export default class ContributionModal extends React.Component<Props, State> {
           description={
             <>
               Your contribution should be confirmed in about 20 minutes. You can keep an
-              eye on it at the <a>contributions tab on your profile</a>.
+              eye on it at the{' '}
+              <Link to="/profile?tab=funded">funded tab on your profile</Link>.
             </>
           }
           style={{ width: '90%' }}

--- a/frontend/client/components/CreateFlow/Final.tsx
+++ b/frontend/client/components/CreateFlow/Final.tsx
@@ -42,8 +42,8 @@ class CreateFinal extends React.Component<Props> {
           <Icon type="check-circle" />
           <div className="CreateFinal-message-text">
             Your proposal has been submitted! Check your{' '}
-            <Link to={`/profile`}>profile's</Link> pending proposals tab to check it's
-            status.
+            <Link to={`/profile?tab=pending`}>profile's pending proposals tab</Link>
+            {' '}to check its status.
           </div>
           {/* TODO - remove or rework depending on design choices */}
           {/* <div className="CreateFinal-message-text">

--- a/frontend/client/components/LinkableTabs.tsx
+++ b/frontend/client/components/LinkableTabs.tsx
@@ -49,7 +49,6 @@ class LinkableTabs extends React.Component<Props, State> {
 
   render() {
     const { defaultActiveKey } = this.state;
-    console.log(defaultActiveKey);
     return <Tabs {...this.props} defaultActiveKey={defaultActiveKey} />;
   }
 

--- a/frontend/client/components/LinkableTabs.tsx
+++ b/frontend/client/components/LinkableTabs.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import qs from 'query-string';
+import { withRouter, RouteComponentProps } from 'react-router';
+import { Tabs } from 'antd';
+import { TabsProps } from 'antd/lib/tabs';
+
+interface OwnProps extends TabsProps {
+  scrollToTabs?: boolean;
+}
+
+type Props = OwnProps & RouteComponentProps;
+
+interface State {
+  defaultActiveKey: string | undefined;
+}
+
+class LinkableTabs extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    let { defaultActiveKey } = props;
+    const tab = this.getTabFromUrl(props.location);
+    if (tab) {
+      defaultActiveKey = tab;
+    }
+    this.state = { defaultActiveKey };
+  }
+
+  componentDidMount() {
+    const tab = this.getTabFromUrl(this.props.location);
+    if (tab && this.props.scrollToTabs) {
+      setTimeout(() => {
+        // Don't wrestle control from the user
+        if (window.scrollY !== 0) {
+          return;
+        }
+
+        const node = findDOMNode(this);
+        if (node instanceof HTMLElement) {
+          window.scrollTo({
+            top: node.offsetTop,
+            behavior: 'smooth',
+          });
+        }
+      }, 500);
+    }
+  }
+
+  render() {
+    const { defaultActiveKey } = this.state;
+    console.log(defaultActiveKey);
+    return <Tabs {...this.props} defaultActiveKey={defaultActiveKey} />;
+  }
+
+  private getTabFromUrl(location: RouteComponentProps['location']): string | undefined {
+    const args = qs.parse(location.search);
+    return args.tab;
+  }
+}
+
+export default withRouter(LinkableTabs);

--- a/frontend/client/components/Profile/index.tsx
+++ b/frontend/client/components/Profile/index.tsx
@@ -22,6 +22,7 @@ import ProfileInvite from './ProfileInvite';
 import Placeholder from 'components/Placeholder';
 import Exception from 'pages/exception';
 import ContributionModal from 'components/ContributionModal';
+import LinkableTabs from 'components/LinkableTabs';
 import './style.less';
 import { UserContribution } from 'types';
 
@@ -109,7 +110,7 @@ class Profile extends React.Component<Props, State> {
             render={() => <ProfileEdit user={user} />}
           />
         </Switch>
-        <Tabs>
+        <LinkableTabs>
           {isAuthedUser && (
             <Tabs.TabPane
               tab={TabTitle('Pending', pendingProposals.length)}
@@ -176,7 +177,7 @@ class Profile extends React.Component<Props, State> {
               </div>
             </Tabs.TabPane>
           )}
-        </Tabs>
+        </LinkableTabs>
 
         <ContributionModal
           isVisible={!!activeContribution}

--- a/frontend/client/components/Profile/index.tsx
+++ b/frontend/client/components/Profile/index.tsx
@@ -59,15 +59,15 @@ class Profile extends React.Component<Props, State> {
     }
   }
   render() {
-    const userLookupParam = this.props.match.params.id;
-    const { authUser, match } = this.props;
+    const { authUser, match, location } = this.props;
     const { activeContribution } = this.state;
+    const userLookupParam = match.params.id;
 
     if (!userLookupParam) {
       if (authUser && authUser.userid) {
-        return <Redirect to={`/profile/${authUser.userid}`} />;
+        return <Redirect to={{ ...location, pathname: `/profile/${authUser.userid}` }} />;
       } else {
-        return <Redirect to="auth" />;
+        return <Redirect to={{ ...location, pathname: '/auth' }} />;
       }
     }
 

--- a/frontend/client/components/Proposal/index.tsx
+++ b/frontend/client/components/Proposal/index.tsx
@@ -141,7 +141,7 @@ export class ProposalDetail extends React.Component<Props, State> {
         blurb: (
           <>
             Your proposal has been approved! It is currently only visible to the team.
-            Visit your <Link to="/profile">profile - pending</Link> tab to publish.
+            Visit your <Link to="/profile?tab=pending">profile's pending tab</Link> to publish.
           </>
         ),
         type: 'success',
@@ -150,7 +150,7 @@ export class ProposalDetail extends React.Component<Props, State> {
         blurb: (
           <>
             Your proposal was rejected and is only visible to the team. Visit your{' '}
-            <Link to="/profile">profile - pending</Link> tab for more information.
+            <Link to="/profile?tab=pending">profile's pending tab</Link> for more information.
           </>
         ),
         type: 'error',

--- a/frontend/client/components/Proposal/index.tsx
+++ b/frontend/client/components/Proposal/index.tsx
@@ -3,6 +3,7 @@ import { compose } from 'recompose';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import Markdown from 'components/Markdown';
+import LinkableTabs from 'components/LinkableTabs';
 import { proposalActions } from 'modules/proposals';
 import { bindActionCreators, Dispatch } from 'redux';
 import { AppState } from 'store/reducers';
@@ -231,7 +232,7 @@ export class ProposalDetail extends React.Component<Props, State> {
           </div>
         </div>
 
-        <Tabs>
+        <LinkableTabs scrollToTabs>
           <Tabs.TabPane tab="Milestones" key="milestones">
             <div style={{ marginTop: '1.5rem', padding: '0 2rem' }}>
               <Milestones proposal={proposal} />
@@ -246,7 +247,7 @@ export class ProposalDetail extends React.Component<Props, State> {
           <Tabs.TabPane tab="Contributors" key="contributors">
             <ContributorsTab proposalId={proposal.proposalId} />
           </Tabs.TabPane>
-        </Tabs>
+        </LinkableTabs>
 
         {isTrustee && (
           <>

--- a/frontend/client/components/Settings/index.tsx
+++ b/frontend/client/components/Settings/index.tsx
@@ -3,6 +3,7 @@ import { AppState } from 'store/reducers';
 import { connect } from 'react-redux';
 import './index.less';
 import { Tabs } from 'antd';
+import LinkableTabs from 'components/LinkableTabs';
 import ChangePassword from './ChangePassword';
 
 const { TabPane } = Tabs;
@@ -21,11 +22,11 @@ class Settings extends React.Component<Props> {
     return (
       <div className="Settings">
         <h1>Settings</h1>
-        <Tabs defaultActiveKey="1" tabPosition="top">
-          <TabPane tab="Change Password" key="1">
+        <LinkableTabs defaultActiveKey="password" tabPosition="top">
+          <TabPane tab="Change Password" key="password">
             <ChangePassword />
           </TabPane>
-        </Tabs>
+        </LinkableTabs>
       </div>
     );
   }

--- a/frontend/client/styles/html.less
+++ b/frontend/client/styles/html.less
@@ -8,6 +8,7 @@
 }
 html {
   font-size: 16px;
+  scroll-behavior: smooth;
 
   @media @tablet-query {
     font-size: 14px;


### PR DESCRIPTION
Closes #64.

### What This Does

Creates a new component called `<LinkableTabs>` that wraps Ant's `<Tabs>` component. It checks the query string for `?tab=[tab]` and sets that tab to the default. If you pass `scrollToTab`, it'll also smooth-scroll down to the specified tab's location on screen. All existing `<Tabs>` have been replaced with `<LinkableTabs>`, and all links to specific tabs have been updated.

This also implements a lot of query param forwarding to redirects, and improves the initial auth redirect. For future reference, the easy way to do this is:
```diff
- return <Redirect to="/path" />;
+ const { location } = this.props;
+ return <Redirect to={{ ...redirect, pathname: '/path' }} />;
```

### Steps to Test

1. While logged in, go to `/profile?tab=invitations`, confirm the query param was carried to `/profile/[userid]?tab=invitations` and that you were taken to the right tab.
2. Go to `/proposal/[proposalid]?tab=contributors`, confirm you were switch and scrolled to the correct tab.
3. Repeat number 2, but start scrolling immediately as the page loads. Confirm you weren't scroll-jacked.