### PR TITLE
A bunch of emails

### DIFF
--- a/admin/src/components/Emails/emails.ts
+++ b/admin/src/components/Emails/emails.ts
@@ -37,6 +37,12 @@ export default [
     description: 'Sent when an a user contributes and it’s been confirmed on-chain',
   },
   {
+    id: 'proposal_comment',
+    title: 'Proposal comment',
+    description:
+      'Sent if someone makes a top-level comment on your proposal. Replies don’t send an email.',
+  },
+  {
     id: 'contribution_confirmed',
     title: 'Contribution confirmed',
     description: 'Sent after a contribution can be confirmed on chain',

--- a/admin/src/components/Emails/emails.ts
+++ b/admin/src/components/Emails/emails.ts
@@ -41,4 +41,9 @@ export default [
     title: 'Contribution confirmed',
     description: 'Sent after a contribution can be confirmed on chain',
   },
+  {
+    id: 'comment_reply',
+    title: 'Comment reply',
+    description: 'Sent if someone makes a direct reply to your comment',
+  },
 ] as Email[];

--- a/admin/src/components/Emails/emails.ts
+++ b/admin/src/components/Emails/emails.ts
@@ -32,6 +32,11 @@ export default [
     description: 'Sent when an admin rejects your submitted proposal',
   },
   {
+    id: 'proposal_contribution',
+    title: 'Proposal received contribution',
+    description: 'Sent when an a user contributes and it’s been confirmed on-chain',
+  },
+  {
     id: 'contribution_confirmed',
     title: 'Contribution confirmed',
     description: 'Sent after a contribution can be confirmed on chain',

--- a/admin/src/components/Emails/emails.ts
+++ b/admin/src/components/Emails/emails.ts
@@ -48,6 +48,11 @@ export default [
     description: 'Sent after a contribution can be confirmed on chain',
   },
   {
+    id: 'contribution_update',
+    title: 'Contributed proposal update',
+    description: 'Sent when a proposal you contributed to posts an update',
+  },
+  {
     id: 'comment_reply',
     title: 'Comment reply',
     description: 'Sent if someone makes a direct reply to your comment',

--- a/backend/grant/admin/example_emails.py
+++ b/backend/grant/admin/example_emails.py
@@ -52,6 +52,13 @@ example_email_args = {
         'proposal_url': 'http://someproposal.com',
         'contributor_url': 'http://someuser.com',
     },
+    'proposal_comment': {
+        'author': user,
+        'proposal': proposal,
+        'preview': 'Blah blah blah blah blah...',
+        'comment_url': 'http://somecomment.com',
+        'author_url': 'http://someuser.com',
+    },
     'contribution_confirmed': {
         'proposal': proposal,
         'contribution': contribution,
@@ -59,6 +66,7 @@ example_email_args = {
     },
     'comment_reply': {
         'author': user,
+        'proposal': proposal,
         'preview': 'Blah blah blah blah blah...',
         'comment_url': 'http://somecomment.com',
         'author_url': 'http://someuser.com',

--- a/backend/grant/admin/example_emails.py
+++ b/backend/grant/admin/example_emails.py
@@ -10,10 +10,11 @@ class FakeProposal(object):
     title = 'Example proposal'
     brief = 'This is an example proposal'
     content = 'Example example example example'
+    target = "100"
 
 class FakeContribution(object):
     id = 123
-    amount = '123'
+    amount = '12.5'
     proposal_id = 123
     user_id = 123
 
@@ -42,6 +43,14 @@ example_email_args = {
         'proposal': proposal,
         'proposal_url': 'http://someproposal.com',
         'admin_note': 'We think that you’ve asked for too much money for the project you’ve proposed, and for such an inexperienced team. Feel free to change your target amount, or elaborate on why you need so much money, and try applying again.',
+    },
+    'proposal_contribution': {
+        'proposal': proposal,
+        'contribution': contribution,
+        'contributor': user,
+        'funded': '50',
+        'proposal_url': 'http://someproposal.com',
+        'contributor_url': 'http://someuser.com',
     },
     'contribution_confirmed': {
         'proposal': proposal,

--- a/backend/grant/admin/example_emails.py
+++ b/backend/grant/admin/example_emails.py
@@ -18,9 +18,16 @@ class FakeContribution(object):
     proposal_id = 123
     user_id = 123
 
+class FakeUpdate(object):
+    id = 123
+    title = 'Example update'
+    content = 'Example example example example\n\nExample example example example'
+    proposal_id = 123
+
 user = FakeUser()
 proposal = FakeProposal()
 contribution = FakeContribution()
+update = FakeUpdate()
 
 example_email_args = {
     'signup': {
@@ -63,6 +70,12 @@ example_email_args = {
         'proposal': proposal,
         'contribution': contribution,
         'tx_explorer_url': 'http://someblockexplorer.com/tx/271857129857192579125',
+    },
+    'contribution_update': {
+        'proposal': proposal,
+        'proposal_update': update,
+        'preview': 'Blah blah blah blah blah blah blah blah blah blah blah blah blah blah...',
+        'update_url': 'http://someupdate.com',
     },
     'comment_reply': {
         'author': user,

--- a/backend/grant/admin/example_emails.py
+++ b/backend/grant/admin/example_emails.py
@@ -57,4 +57,10 @@ example_email_args = {
         'contribution': contribution,
         'tx_explorer_url': 'http://someblockexplorer.com/tx/271857129857192579125',
     },
+    'comment_reply': {
+        'author': user,
+        'preview': 'Blah blah blah blah blah...',
+        'comment_url': 'http://somecomment.com',
+        'author_url': 'http://someuser.com',
+    },
 }

--- a/backend/grant/admin/views.py
+++ b/backend/grant/admin/views.py
@@ -156,4 +156,8 @@ def approve_proposal(id, is_approve, reject_reason=None):
 @endpoint.api()
 @auth_required
 def get_email_example(type):
-    return generate_email(type, example_email_args.get(type))
+    email = generate_email(type, example_email_args.get(type))
+    if email['info'].get('subscription'):
+        # Unserializable, so remove
+        email['info'].pop('subscription', None)
+    return email

--- a/backend/grant/comment/models.py
+++ b/backend/grant/comment/models.py
@@ -33,17 +33,6 @@ class Comment(db.Model):
             .filter(Comment.user_id == user.id) \
             .order_by(Comment.date_created.desc()) \
             .all()
-    
-    def make_preview(self):
-        # Truncate to first line only, max 60 chars. Add ellipsis if truncated.
-        truncated = False
-        preview = self.content.split('\n', 1)[0]
-        if len(preview) != len(self.content):
-            truncated = True
-        if len(preview) > 60:
-            preview = preview[:57]
-            truncated = True
-        return self.content + '...' if truncated else self.content
 
 
 class CommentSchema(ma.Schema):

--- a/backend/grant/comment/models.py
+++ b/backend/grant/comment/models.py
@@ -33,6 +33,17 @@ class Comment(db.Model):
             .filter(Comment.user_id == user.id) \
             .order_by(Comment.date_created.desc()) \
             .all()
+    
+    def make_preview(self):
+        # Truncate to first line only, max 60 chars. Add ellipsis if truncated.
+        truncated = False
+        preview = self.content.split('\n', 1)[0]
+        if len(preview) != len(self.content):
+            truncated = True
+        if len(preview) > 60:
+            preview = preview[:57]
+            truncated = True
+        return self.content + '...' if truncated else self.content
 
 
 class CommentSchema(ma.Schema):

--- a/backend/grant/email/send.py
+++ b/backend/grant/email/send.py
@@ -55,6 +55,18 @@ def proposal_rejected(email_args):
         'subscription': EmailSubscription.MY_PROPOSAL_APPROVAL
     }
 
+def proposal_contribution(email_args):
+    return {
+        'subject': 'You just got a contribution!',
+        'title': 'You just got a contribution',
+        'preview': '{} just contributed {} to your proposal {}'.format(
+            email_args['contributor'].display_name,
+            email_args['contribution'].amount,
+            email_args['proposal'].title,
+        ),
+        'subscription': EmailSubscription.MY_PROPOSAL_FUNDED,
+    }
+
 
 def contribution_confirmed(email_args):
     return {
@@ -73,11 +85,13 @@ get_info_lookup = {
     'recover': recover_info,
     'proposal_approved': proposal_approved,
     'proposal_rejected': proposal_rejected,
+    'proposal_contribution': proposal_contribution,
     'contribution_confirmed': contribution_confirmed,
 }
 
 
-def generate_email(type, email_args, info):
+def generate_email(type, email_args):
+    info = get_info_lookup[type](email_args)
     body_text = render_template('emails/%s.txt' % (type), args=email_args)
     body_html = render_template('emails/%s.html' % (type), args=email_args)
 
@@ -113,7 +127,7 @@ def send_email(to, type, email_args):
             return
 
     try:
-        email = generate_email(type, email_args, info)
+        email = generate_email(type, email_args)
         sg = sendgrid.SendGridAPIClient(apikey=SENDGRID_API_KEY)
 
         mail = Mail(

--- a/backend/grant/email/send.py
+++ b/backend/grant/email/send.py
@@ -78,6 +78,14 @@ def contribution_confirmed(email_args):
         ),
     }
 
+def comment_reply(email_args):
+    return {
+        'subject': 'New reply from {}'.format(email_args['author'].display_name),
+        'title': 'You got a reply',
+        'preview': '{} has replied to a comment you posted'.format(email_args['author'].display_name),
+        'subscription': EmailSubscription.MY_COMMENT_REPLY,
+    }
+
 
 get_info_lookup = {
     'signup': signup_info,
@@ -87,6 +95,7 @@ get_info_lookup = {
     'proposal_rejected': proposal_rejected,
     'proposal_contribution': proposal_contribution,
     'contribution_confirmed': contribution_confirmed,
+    'comment_reply': comment_reply,
 }
 
 

--- a/backend/grant/email/send.py
+++ b/backend/grant/email/send.py
@@ -67,6 +67,16 @@ def proposal_contribution(email_args):
         'subscription': EmailSubscription.MY_PROPOSAL_FUNDED,
     }
 
+def proposal_comment(email_args):
+    return {
+        'subject': 'New comment from {}'.format(email_args['author'].display_name),
+        'title': 'You got a comment',
+        'preview': '{} has added a comment to your proposal {}'.format(
+            email_args['author'].display_name,
+            email_args['proposal'].title,
+        ),
+        'subscription': EmailSubscription.MY_PROPOSAL_COMMENT,
+    }
 
 def contribution_confirmed(email_args):
     return {
@@ -94,6 +104,7 @@ get_info_lookup = {
     'proposal_approved': proposal_approved,
     'proposal_rejected': proposal_rejected,
     'proposal_contribution': proposal_contribution,
+    'proposal_comment': proposal_comment,
     'contribution_confirmed': contribution_confirmed,
     'comment_reply': comment_reply,
 }

--- a/backend/grant/email/send.py
+++ b/backend/grant/email/send.py
@@ -86,6 +86,18 @@ def contribution_confirmed(email_args):
             email_args['contribution'].amount,
             email_args['proposal'].title
         ),
+        'subscription': EmailSubscription.FUNDED_PROPOSAL_CONTRIBUTION,
+    }
+
+def contribution_update(email_args):
+    return {
+        'subject': 'The {} team posted an update'.format(email_args['proposal'].title),
+        'title': 'New update',
+        'preview': 'The {} team has posted a new update entitled "{}"'.format(
+            email_args['proposal'].title,
+            email_args['proposal_update'].title,
+        ),
+        'subscription': EmailSubscription.FUNDED_PROPOSAL_UPDATE,
     }
 
 def comment_reply(email_args):
@@ -106,6 +118,7 @@ get_info_lookup = {
     'proposal_contribution': proposal_contribution,
     'proposal_comment': proposal_comment,
     'contribution_confirmed': contribution_confirmed,
+    'contribution_update': contribution_update,
     'comment_reply': comment_reply,
 }
 

--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -308,6 +308,13 @@ class Proposal(db.Model):
         self.date_published = datetime.datetime.now()
         self.status = LIVE
 
+    def get_amount_funded(self):
+        contributions = ProposalContribution.query \
+            .filter_by(proposal_id=self.id, status=CONFIRMED) \
+            .all()
+        funded = reduce(lambda prev, c: prev + float(c.amount), contributions, 0)
+        return str(funded)
+
 
 class ProposalSchema(ma.Schema):
     class Meta:
@@ -361,11 +368,7 @@ class ProposalSchema(ma.Schema):
         return dt_to_unix(obj.date_published) if obj.date_published else None
 
     def get_funded(self, obj):
-        contributions = ProposalContribution.query \
-            .filter_by(proposal_id=obj.id, status=CONFIRMED) \
-            .all()
-        funded = reduce(lambda prev, c: prev + float(c.amount), contributions, 0)
-        return str(funded)
+        return obj.get_amount_funded()
 
 
 proposal_schema = ProposalSchema()

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -13,7 +13,7 @@ from grant.user.models import User, SocialMedia, Avatar
 from grant.email.send import send_email
 from grant.utils.auth import requires_auth, requires_team_member_auth, get_authed_user, internal_webhook
 from grant.utils.exceptions import ValidationException
-from grant.utils.misc import is_email, make_url, from_zat
+from grant.utils.misc import is_email, make_url, from_zat, make_preview
 from .models import (
     Proposal,
     proposals_schema,
@@ -105,12 +105,13 @@ def post_proposal_comments(proposal_id, comment, parent_comment_id):
     dumped_comment = comment_schema.dump(comment)
 
     # TODO: Email proposal team if top-level comment
+    preview = make_preview(comment.content, 60)
     if not parent:
         for member in proposal.team:
             send_email(member.email_address, 'proposal_comment', {
                 'author': g.current_user,
                 'proposal': proposal,
-                'preview': comment.make_preview(),
+                'preview': preview,
                 'comment_url': make_url(f'/proposal/{proposal.id}?tab=discussions&comment={comment.id}'),
                 'author_url': make_url(f'/profile/{comment.author.id}'),
             })
@@ -119,7 +120,7 @@ def post_proposal_comments(proposal_id, comment, parent_comment_id):
         send_email(parent.author.email_address, 'comment_reply', {
             'author': g.current_user,
             'proposal': proposal,
-            'preview': comment.make_preview(),
+            'preview': preview,
             'comment_url': make_url(f'/proposal/{proposal.id}?tab=discussions&comment={comment.id}'),
             'author_url': make_url(f'/profile/{comment.author.id}'),
         })
@@ -295,6 +296,17 @@ def post_proposal_update(proposal_id, title, content):
     )
     db.session.add(update)
     db.session.commit()
+
+    # Send email to all contributors (even if contribution failed)
+    preview = make_preview(update.content, 200)
+    contributions = ProposalContribution.query.filter_by(proposal_id=proposal_id).all()
+    for c in contributions:
+        send_email(c.user.email_address, 'contribution_update', {
+            'proposal': g.current_proposal,
+            'proposal_update': update,
+            'preview': preview,
+            'update_url': make_url(f'/proposals/{proposal_id}?tab=updates&update={update.id}'),
+        })
 
     dumped_update = proposal_update_schema.dump(update)
     return dumped_update, 201

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -104,12 +104,21 @@ def post_proposal_comments(proposal_id, comment, parent_comment_id):
     db.session.commit()
     dumped_comment = comment_schema.dump(comment)
 
-    # TODO: Email proposal team
-
+    # TODO: Email proposal team if top-level comment
+    if not parent:
+        for member in proposal.team:
+            send_email(member.email_address, 'proposal_comment', {
+                'author': g.current_user,
+                'proposal': proposal,
+                'preview': comment.make_preview(),
+                'comment_url': make_url(f'/proposal/{proposal.id}?tab=discussions&comment={comment.id}'),
+                'author_url': make_url(f'/profile/{comment.author.id}'),
+            })
     # Email parent comment creator, if it's not themselves
     if parent and parent.author.id != comment.author.id:
         send_email(parent.author.email_address, 'comment_reply', {
             'author': g.current_user,
+            'proposal': proposal,
             'preview': comment.make_preview(),
             'comment_url': make_url(f'/proposal/{proposal.id}?tab=discussions&comment={comment.id}'),
             'author_url': make_url(f'/profile/{comment.author.id}'),

--- a/backend/grant/templates/emails/comment_reply.html
+++ b/backend/grant/templates/emails/comment_reply.html
@@ -1,0 +1,24 @@
+<p style="margin: 0 0 20px;">
+  You just received a reply from
+  <a href="{{ args.author_url }}" target="_blank">{{ args.author.display_name }}</a>:
+</p>
+
+<p style="margin: 10px 0; padding: 20px; background: #F8F8F8;">
+  “{{ args.preview }}”
+</p>
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+    <tr>
+      <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
+        <table border="0" cellspacing="0" cellpadding="0">
+          <tr>
+            <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+              <a href="{{ args.comment_url }}" target="_blank" style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;">
+                View their comment
+              </a>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>

--- a/backend/grant/templates/emails/comment_reply.html
+++ b/backend/grant/templates/emails/comment_reply.html
@@ -1,6 +1,7 @@
 <p style="margin: 0 0 20px;">
   You just received a reply from
-  <a href="{{ args.author_url }}" target="_blank">{{ args.author.display_name }}</a>:
+  <a href="{{ args.author_url }}" target="_blank">{{ args.author.display_name }}</a>
+  on <strong>{{ args.proposal.title }}</strong>:
 </p>
 
 <p style="margin: 10px 0; padding: 20px; background: #F8F8F8;">

--- a/backend/grant/templates/emails/comment_reply.txt
+++ b/backend/grant/templates/emails/comment_reply.txt
@@ -1,4 +1,4 @@
-You just received a reply from {{ args.author.display_name }}:
+You just received a reply from {{ args.author.display_name }} on {{ args.proposal.title }}:
 
 > {{ args.preview }}
 

--- a/backend/grant/templates/emails/comment_reply.txt
+++ b/backend/grant/templates/emails/comment_reply.txt
@@ -1,0 +1,6 @@
+You just received a reply from {{ args.author.display_name }}:
+
+> {{ args.preview }}
+
+Go here to see their response: {{ args.comment_url }}
+Go here to see their profile: {{ args.author_url }}

--- a/backend/grant/templates/emails/contribution_update.html
+++ b/backend/grant/templates/emails/contribution_update.html
@@ -1,0 +1,32 @@
+<p style="margin: 0;">
+  A proposal you follow, <strong>{{ args.proposal.title }}</strong>, has
+  posted an update:
+</p>
+
+<div style="margin: 10px 0; padding: 20px; background: #F8F8F8;">
+  <h2 style="margin: 0 0 20px 0; font-size: 20px; font-weight: bold;">
+    {{ args.proposal_update.title }}
+  </h2>
+  <p style="margin: 0;">{{ args.preview }}</p>
+</div>
+  
+  <table width="100%" border="0" cellspacing="0" cellpadding="0">
+    <tr>
+      <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
+        <table border="0" cellspacing="0" cellpadding="0">
+          <tr>
+            <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+              <a
+                href="{{ args.update_url }}"
+                target="_blank"
+                style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;"
+              >
+                View the full update
+              </a>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+  

--- a/backend/grant/templates/emails/contribution_update.txt
+++ b/backend/grant/templates/emails/contribution_update.txt
@@ -1,0 +1,2 @@
+A proposal you follow, "{{ args.proposal.title }}", has posted an update.
+Go here to view it in full: {{ args.update_url }}

--- a/backend/grant/templates/emails/proposal_comment.html
+++ b/backend/grant/templates/emails/proposal_comment.html
@@ -1,0 +1,24 @@
+<p style="margin: 0 0 20px;">
+    Your proposal <strong>{{ args.proposal.title }}</strong> just received a comment from
+    <a href="{{ args.author_url }}" target="_blank">{{ args.author.display_name }}</a>:
+  </p>
+
+  <p style="margin: 10px 0; padding: 20px; background: #F8F8F8;">
+    “{{ args.preview }}”
+  </p>
+
+  <table width="100%" border="0" cellspacing="0" cellpadding="0">
+      <tr>
+        <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
+          <table border="0" cellspacing="0" cellpadding="0">
+            <tr>
+              <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+                <a href="{{ args.comment_url }}" target="_blank" style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;">
+                  View their comment
+                </a>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>

--- a/backend/grant/templates/emails/proposal_comment.txt
+++ b/backend/grant/templates/emails/proposal_comment.txt
@@ -1,0 +1,6 @@
+Your proposal "{{ args.proposal.title }}" just received a comment from {{ args.author.display_name }}:
+
+> {{ args.preview }}
+
+Go here to see their comment: {{ args.comment_url }}
+Go here to see their profile: {{ args.author_url }}

--- a/backend/grant/templates/emails/proposal_contribution.html
+++ b/backend/grant/templates/emails/proposal_contribution.html
@@ -1,0 +1,23 @@
+<p style="margin: 0 0 20px;">
+  Your proposal <strong>{{ args.proposal.title }}</strong> just got a
+  <strong>{{ args.contribution.amount }} ZEC</strong> contribution from
+  <a href="{{ args.contributor_url }}" target="_blank">{{ args.contributor.display_name }}</a>.
+  Your proposal is now at
+  <strong>{{ args.funded }} / {{ args.proposal.target }} ZEC</strong>.
+</p>
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
+      <table border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+            <a href="{{ args.proposal_url }}" target="_blank" style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;">
+              View your Proposal
+            </a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/backend/grant/templates/emails/proposal_contribution.txt
+++ b/backend/grant/templates/emails/proposal_contribution.txt
@@ -1,0 +1,6 @@
+Your proposal "{{ args.proposal.title }}" just got a
+{{ args.contribution.amount }} ZEC contribution from
+{{ args.contributor.display_name }}. Your proposal is now at {{ args.funded }} / {{ args.proposal.target }} ZEC.
+
+See {{ args.contributor.display_name }}'s profile: {{ args.contributor_url }}
+View your proposal: {{ args.proposal_url }}

--- a/backend/grant/utils/misc.py
+++ b/backend/grant/utils/misc.py
@@ -36,3 +36,19 @@ def from_zat(zat: int):
 
 def to_zat(zec: float):
   return zec * 100000000
+
+def make_preview(content: str, max_length: int):
+  truncated = False
+
+  # Show only the first line. Add ellipsis if there are more than two lines,
+  # even if first line isn't truncated.
+  preview = content.split('\n', 1)[0]
+  if len(preview) != len(content):
+      truncated = True
+
+  # Truncate to max length
+  if len(preview) > max_length:
+      preview = preview[:max_length - 3]
+      truncated = True
+
+  return content + '...' if truncated else content


### PR DESCRIPTION
Knocks out a bunch of #12, still not all. Relies on #75.

### What This Does

* Adds emails for the following cases:
  * Proposal comments for proposal team
  * Comment replies for comment creator
  * Proposal updates for proposal contributors
  * Contribution confirmation for contributor & proposal team
* Fixes the email admin from #75.

### Steps to Test

* Create two accounts, and on one of them a new proposal
* As another user, post a comment on that proposal. Confirm you get an email as the creator of the proposal.
* As the creator of the proposal, reply to that comment. Confirm you get an email as the author of the parent comment.
* As the non-creator, fund the proposal. Confirm you get a confirmation email after it confirms. Confirm you get an email as the proposal creator that you got a new contribution.
* As the creator of the proposal, create a new proposal update. Confirm you get an email as the contributor user.

## Screenshots

Not all of them, but here's the gist

<img width="937" alt="screen shot 2019-01-14 at 2 07 45 pm" src="https://user-images.githubusercontent.com/649992/51139813-e6abaf80-1812-11e9-914e-3792deb8789d.png">
<img width="1019" alt="screen shot 2019-01-14 at 2 43 31 pm" src="https://user-images.githubusercontent.com/649992/51139817-e8757300-1812-11e9-9271-6550602b4ff3.png">
<img width="1017" alt="screen shot 2019-01-14 at 2 43 45 pm" src="https://user-images.githubusercontent.com/649992/51139821-ea3f3680-1812-11e9-96fc-c8131dc94999.png">
