### PR TITLE
blockchain: default & required env vars

### DIFF
--- a/blockchain/.env.example
+++ b/blockchain/.env.example
@@ -1,20 +1,22 @@
-# Shared Server Config
-API_SECRET_HASH="4747c3a7d043640cd8ed4e6b72bb9562d2585cee65681eb9c21ffec03c0bf560"
-API_SECRET_KEY="ef0b48e41f78d3ae85b1379b386f1bca"
-
 # Webhooks Config
 WEBHOOK_URL="http://localhost:5000/api/v1"
 
 # REST Server Config
-REST_SERVER_PORT="5051"
+PORT="5051"
 
 # ZCash Node (Defaults are for regtest)
 ZCASH_NODE_URL="http://localhost:18232"
 ZCASH_NODE_USERNAME="zcash_user"
 ZCASH_NODE_PASSWORD="zcash_password"
-MINIMUM_BLOCK_CONFIRMATIONS=6
+MINIMUM_BLOCK_CONFIRMATIONS="6"
+
+# Shared Server Config, run `yarn genkey` to generate
+API_SECRET_HASH=""
+API_SECRET_KEY=""
 
 # Addresses, run `yarn genaddress` to get sprout information
-# SPROUT_ADDRESS="123"
-# SPROUT_VIEWKEY="456"
-BIP32_XPUB="xpub..."
+SPROUT_ADDRESS=""
+SPROUT_VIEWKEY=""
+
+# extended public seed
+BIP32_XPUB=""

--- a/blockchain/src/env.ts
+++ b/blockchain/src/env.ts
@@ -2,22 +2,38 @@ import dotenv from "dotenv";
 dotenv.load();
 
 // Maps to .env.example variables, plus any node ones we use
-interface CustomEnvironment {
-  API_SECRET_HASH: string;
-  API_SECRET_KEY: string;
+// fill in sensible defaults, falsy values will throw if not set
+const DEFAULTS = {
+  API_SECRET_HASH: "",
+  API_SECRET_KEY: "",
 
-  WEBHOOK_URL: string;
-  PORT: string;
+  WEBHOOK_URL: "",
+  PORT: "5051",
 
-  ZCASH_NODE_URL: string;
-  ZCASH_NODE_USERNAME: string;
-  ZCASH_NODE_PASSWORD: string;
-  MINIMUM_BLOCK_CONFIRMATIONS: string;
+  ZCASH_NODE_URL: "",
+  ZCASH_NODE_USERNAME: "",
+  ZCASH_NODE_PASSWORD: "",
+  MINIMUM_BLOCK_CONFIRMATIONS: "6",
 
-  SPROUT_ADDRESS: string;
-  SPROUT_VIEWKEY: string;
-  BIP32_XPUB: string;
-  BIP44_ACCOUNT: string;
-}
+  SPROUT_ADDRESS: "",
+  SPROUT_VIEWKEY: "",
+  BIP32_XPUB: ""
+  // can't find any refs to this
+  // BIP44_ACCOUNT: ""
+};
 
-export default process.env as any as CustomEnvironment;
+type CustomEnvironment = typeof DEFAULTS;
+
+Object.entries(DEFAULTS).forEach(([k, v]) => {
+  if (!process.env[k]) {
+    const defVal = (DEFAULTS as any)[k];
+    if (defVal) {
+      console.log(`Using default environment variable ${k}="${defVal}"`);
+      process.env[k] = defVal;
+    } else {
+      throw new Error(`Missing required environment variable ${k}`);
+    }
+  }
+});
+
+export default (process.env as any) as CustomEnvironment;


### PR DESCRIPTION
Closes #82.

### What this does
- fix up `.env.example` a bit
- errors on missing env variables without default values
- sets defaults for missing env vars and reports doing so via `console.log`
- provides default `PORT="5051"`, `MINIMUM_BLOCK_CONFIRMATIONS="6"`

### Test
- comment out a required env var from `.env`, then `yarn dev` should throw Error giving missing key name
- unset `PORT` env variable, `yarn dev` and note console output:
```
...
Using default environment variable PORT="5051"
...
```