### PR TITLE
Email & admin branding replacement

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -1,6 +1,6 @@
-# Grant.io Admin UI
+# ZF Grants Admin UI
 
-This is the admin component of [Grant.io](http://grant.io).
+This is the admin component of [grants.zfnd.org](http://grants.zfnd.org).
 
 ## Development
 

--- a/admin/src/components/Emails/Example.tsx
+++ b/admin/src/components/Emails/Example.tsx
@@ -21,7 +21,7 @@ export default class Example extends React.Component<Props> {
             <div className="Example-inbox-left">
               <div className="Example-inbox-left-icon is-checkbox" />
               <div className="Example-inbox-left-icon is-favorite" />
-              <div className="Example-inbox-left-sender">Grant.io</div>
+              <div className="Example-inbox-left-sender">ZF Grants</div>
             </div>
             <div className="Example-inbox-subject">
               <strong>{email.info.subject}</strong>

--- a/admin/src/components/Template/index.tsx
+++ b/admin/src/components/Template/index.tsx
@@ -30,7 +30,7 @@ class Template extends React.Component<Props> {
           </div>
         )}
         <Sider className="Template-sider">
-          <div className="Template-sider-logo">grant.io</div>
+          <div className="Template-sider-logo">ZF Grants</div>
           <Menu theme="dark" mode="inline" selectedKeys={[pathname]}>
             <Menu.Item key="/">
               <Link to="/">

--- a/admin/src/static/index.html
+++ b/admin/src/static/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charSet="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Admin - Grant.io</title>
+  <title>Admin - ZF Grants</title>
 </head>
 
 <body>

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,7 @@
 # Environment variable overrides for local development
 FLASK_APP=app.py
 FLASK_ENV=development
-SITE_URL="https://grant.io" # No trailing slash
+SITE_URL="https://zfnd.org" # No trailing slash
 DATABASE_URL="sqlite:////tmp/dev.db"
 REDISTOGO_URL="redis://localhost:6379"
 SECRET_KEY="not-so-secret"

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
-# Grant.io Backend
+# ZF Grants Backend
 
-This is the backend component of [Grant.io](http://grant.io).
+This is the backend component of [grants.zfnd.org](http://grants.zfnd.org).
 
 ## Environment Setup
 
@@ -89,16 +89,6 @@ To create a proposal, run
 
     flask create_proposal "FUNDING_REQUIRED" 1 123 "My Awesome Proposal" "### Hi! I have a great proposal"
 
-## External Services
-
-To decode EIP-712 signed messages, a Grant.io deployed service was created `https://eip-712.herokuapp.com`.
-
-To adjust this endpoint, simply export `AUTH_URL` with a new endpoint value:
-
-    export AUTH_URL=http://new-endpoint.com
-
-To learn more about this auth service, you can visit the repo [here](https://github.com/grant-project/eip-712-server).
-
 ## S3 Storage Setup
 
 1. create bucket, keep the `bucket name` and `region` handy
@@ -158,7 +148,7 @@ These instructions are for `development`, for `production` simply replace all ho
 1. Create Twitter oauth app https://developer.twitter.com/en/apply/user
 
    1. click **Create an App**
-   1. set **Website URL** to a valid URL, such as `http://demo.grant.io`
+   1. set **Website URL** to a valid URL, such as `http://grants.zfnd.org`
    1. check the **Enable Sign in with Twitter** option
    1. set **Callback URLs** to `http://127.0.0.1:3000/callback/twitter`
    1. fill out other required fields

--- a/backend/grant/email/send.py
+++ b/backend/grant/email/send.py
@@ -1,24 +1,25 @@
 import sendgrid
 from flask import render_template, Markup, current_app
-from grant.settings import SENDGRID_API_KEY, SENDGRID_DEFAULT_FROM
+from grant.settings import SENDGRID_API_KEY, SENDGRID_DEFAULT_FROM, UI
+from grant.utils.misc import make_url
 from python_http_client import HTTPError
 from sendgrid.helpers.mail import Email, Mail, Content
 
 from .subscription_settings import EmailSubscription, is_subscribed
 
 default_template_args = {
-    'home_url': 'https://grant.io',
-    'account_url': 'https://grant.io/user',
-    'email_settings_url': 'https://grant.io/user/settings',
-    'unsubscribe_url': 'https://grant.io/unsubscribe',
+    'home_url': make_url('/'),
+    'account_url': make_url('/user'),
+    'email_settings_url': make_url('/settings'),
+    'unsubscribe_url': make_url('/unsubscribe'),
 }
 
 
 def signup_info(email_args):
     return {
-        'subject': 'Confirm your email on Grant.io',
-        'title': 'Welcome to Grant.io!',
-        'preview': 'Welcome to Grant.io, we just need to confirm your email address.',
+        'subject': 'Confirm your email on {}'.format(UI['NAME']),
+        'title': 'Welcome to {}!'.format(UI['NAME']),
+        'preview': 'Welcome to {}, we just need to confirm your email address.'.format(UI['NAME']),
     }
 
 
@@ -32,8 +33,8 @@ def team_invite_info(email_args):
 
 def recover_info(email_args):
     return {
-        'subject': 'Grant.io account recovery',
-        'title': 'Grant.io account recovery',
+        'subject': '{} account recovery'.format(UI['NAME']),
+        'title': '{} account recovery'.format(UI['NAME']),
         'preview': 'Use the link to recover your account.'
     }
 
@@ -50,7 +51,7 @@ def change_email_old_info(email_args):
     return {
         'subject': 'Your email has been changed',
         'title': 'Email changed',
-        'preview': 'Your email address has been updated on ZF Grants'
+        'preview': 'Your email address has been updated on {}'.format(UI['NAME']),
     }
 
 
@@ -157,19 +158,35 @@ get_info_lookup = {
 
 def generate_email(type, email_args):
     info = get_info_lookup[type](email_args)
-    body_text = render_template('emails/%s.txt' % (type), args=email_args)
-    body_html = render_template('emails/%s.html' % (type), args=email_args)
+    body_text = render_template(
+        'emails/%s.txt' % (type),
+        args=email_args,
+        UI=UI,
+    )
+    body_html = render_template(
+        'emails/%s.html' % (type),
+        args=email_args,
+        UI=UI,
+    )
 
-    html = render_template('emails/template.html', args={
-        **default_template_args,
-        **info,
-        'body': Markup(body_html),
-    })
-    text = render_template('emails/template.txt', args={
-        **default_template_args,
-        **info,
-        'body': body_text,
-    })
+    html = render_template(
+        'emails/template.html',
+        args={
+            **default_template_args,
+            **info,
+            'body': Markup(body_html),
+        },
+        UI=UI,
+    )
+    text = render_template(
+        'emails/template.txt',
+        args={
+            **default_template_args,
+            **info,
+            'body': body_text,
+        },
+        UI=UI,
+    )
 
     return {
         'info': info,

--- a/backend/grant/settings.py
+++ b/backend/grant/settings.py
@@ -13,7 +13,7 @@ env.read_env()
 
 ENV = env.str("FLASK_ENV", default="production")
 DEBUG = ENV == "development"
-SITE_URL = env.str('SITE_URL', default='https://grant.io')
+SITE_URL = env.str('SITE_URL', default='https://zfnd.org')
 SQLALCHEMY_DATABASE_URI = env.str("DATABASE_URL")
 QUEUES = ["default"]
 SECRET_KEY = env.str("SECRET_KEY")
@@ -24,7 +24,7 @@ CACHE_TYPE = "simple"  # Can be "memcached", "redis", etc.
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 SENDGRID_API_KEY = env.str("SENDGRID_API_KEY", default="")
-SENDGRID_DEFAULT_FROM = "noreply@grant.io"
+SENDGRID_DEFAULT_FROM = "noreply@zfnd.org"
 
 SENTRY_DSN = env.str("SENTRY_DSN", default=None)
 SENTRY_RELEASE = env.str("SENTRY_RELEASE", default=None)
@@ -51,3 +51,9 @@ BLOCKCHAIN_REST_API_URL = env.str("BLOCKCHAIN_REST_API_URL")
 BLOCKCHAIN_API_SECRET = env.str("BLOCKCHAIN_API_SECRET")
 
 ADMIN_PASS_HASH = env.str("ADMIN_PASS_HASH")
+
+UI = {
+  'NAME': 'ZF Grants',
+  'PRIMARY': '#CF8A00',
+  'SECONDARY': '#2D2A26',
+}

--- a/backend/grant/templates/emails/comment_reply.html
+++ b/backend/grant/templates/emails/comment_reply.html
@@ -13,9 +13,9 @@
         <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+                    <td align="center" style="border-radius: 3px;" bgcolor="{{ UI.PRIMARY }}">
                         <a href="{{ args.comment_url }}" target="_blank"
-                           style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;">
+                           style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{ UI.PRIMARY }}; display: inline-block;">
                             View their comment
                         </a>
                     </td>

--- a/backend/grant/templates/emails/contribution_update.html
+++ b/backend/grant/templates/emails/contribution_update.html
@@ -15,11 +15,11 @@
         <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+                    <td align="center" style="border-radius: 3px;" bgcolor="{{ UI.PRIMARY }}">
                         <a
                                 href="{{ args.update_url }}"
                                 target="_blank"
-                                style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;"
+                                style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{ UI.PRIMARY }}; display: inline-block;"
                         >
                             View the full update
                         </a>

--- a/backend/grant/templates/emails/proposal_approved.html
+++ b/backend/grant/templates/emails/proposal_approved.html
@@ -18,11 +18,11 @@
         <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+                    <td align="center" style="border-radius: 3px;" bgcolor="{{ UI.PRIMARY }}">
                         <a
                                 href="{{ args.proposal_url }}"
                                 target="_blank"
-                                style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;"
+                                style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{ UI.PRIMARY }}; display: inline-block;"
                         >
                             Publish your proposal
                         </a>

--- a/backend/grant/templates/emails/proposal_comment.html
+++ b/backend/grant/templates/emails/proposal_comment.html
@@ -12,9 +12,9 @@
         <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+                    <td align="center" style="border-radius: 3px;" bgcolor="{{ UI.PRIMARY }}">
                         <a href="{{ args.comment_url }}" target="_blank"
-                           style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;">
+                           style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{ UI.PRIMARY }}; display: inline-block;">
                             View their comment
                         </a>
                     </td>

--- a/backend/grant/templates/emails/proposal_contribution.html
+++ b/backend/grant/templates/emails/proposal_contribution.html
@@ -11,9 +11,9 @@
         <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+                    <td align="center" style="border-radius: 3px;" bgcolor="{{ UI.PRIMARY }}">
                         <a href="{{ args.proposal_url }}" target="_blank"
-                           style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;">
+                           style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{ UI.PRIMARY }}; display: inline-block;">
                             View your Proposal
                         </a>
                     </td>

--- a/backend/grant/templates/emails/recover.html
+++ b/backend/grant/templates/emails/recover.html
@@ -8,11 +8,11 @@
         <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+                    <td align="center" style="border-radius: 3px;" bgcolor="{{ UI.PRIMARY }}">
                         <a
                                 href="{{ args.recover_url }}"
                                 target="_blank"
-                                style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;"
+                                style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{ UI.PRIMARY }}; display: inline-block;"
                         >
                             Reset Password
                         </a>
@@ -28,7 +28,7 @@
 </p>
 
 <p style="margin: 0 0 30px; font-size: 12px; text-align: center;">
-    <a href="{{ args.recover_url }}" target="_blank" style="color: #530EEC;">{{
+    <a href="{{ args.recover_url }}" target="_blank" style="color: {{ UI.PRIMARY }};">{{
         args.recover_url
         }}</a>
 </p>

--- a/backend/grant/templates/emails/signup.html
+++ b/backend/grant/templates/emails/signup.html
@@ -7,9 +7,9 @@
         <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+                    <td align="center" style="border-radius: 3px;" bgcolor="{{ UI.PRIMARY }}">
                         <a href="{{ args.confirm_url }}" target="_blank"
-                           style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;">
+                           style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{ UI.PRIMARY }}; display: inline-block;">
                             Confirm Email
                         </a>
                     </td>
@@ -24,7 +24,9 @@
 </p>
 
 <p style="margin: 0 0 30px; font-size: 12px; text-align: center;">
-    <a href="{{ args.confirm_url }}" target="_blank" style="color: #530EEC;">{{ args.confirm_url }}</a>
+    <a href="{{ args.confirm_url }}" target="_blank" style="color: {{ UI.PRIMARY }};">
+        {{ args.confirm_url }}
+    </a>
 </p>
 
 <p style="margin: 0; font-size: 10px; color: #AAA; text-align: center;">

--- a/backend/grant/templates/emails/team_invite.html
+++ b/backend/grant/templates/emails/team_invite.html
@@ -2,13 +2,13 @@
     You’ve been invited by <strong>{{ args.inviter.display_name }}</strong> to
     join the team for
     <strong>{{ args.proposal.title or '<em>Untitled Project</em>'|safe }}</strong
-    >, a project on Grant.io! If you want to accept the invitation, continue to
+    >, a project on {{ UI.NAME }}! If you want to accept the invitation, continue to
     the site below.
 </p>
 
 {% if not args.user %}
 <p style="margin: 20px 0 0;">
-    It looks like you don't yet have a Grant.io account, so you'll need to sign up
+    It looks like you don't yet have a {{ UI.NAME }} account, so you'll need to sign up
     first before you can join the team.
 </p>
 {% endif %}
@@ -18,11 +18,11 @@
         <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 0 30px;">
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td align="center" style="border-radius: 3px;" bgcolor="#530EEC">
+                    <td align="center" style="border-radius: 3px;" bgcolor="{{ UI.PRIMARY }}">
                         <a
                                 href="{{ args.invite_url }}"
                                 target="_blank"
-                                style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid #530EEC; display: inline-block;"
+                                style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{ UI.PRIMARY }}; display: inline-block;"
                         >
                             {% if args.user %} See invitation {% else %} Get started {% endif %}
                         </a>

--- a/backend/grant/templates/emails/team_invite.txt
+++ b/backend/grant/templates/emails/team_invite.txt
@@ -1,10 +1,10 @@
 You’ve been invited by {{ args.inviter.display_name }} to join the team for
-{{ args.proposal.title or 'Untitled Project' }}, a project on Grant.io! If
+{{ args.proposal.title or 'Untitled Project' }}, a project on {{ UI.NAME }}! If
 you want to accept the invitation, continue to the URL below.
 
 {{ args.invite_url }}
 
 {% if not args.user %}
-It looks like you don't yet have a Grant.io account, so you'll need to sign
+It looks like you don't yet have a {{ UI.NAME }} account, so you'll need to sign
 up first before you can join the team.
 {% endif %}

--- a/backend/grant/templates/emails/template.html
+++ b/backend/grant/templates/emails/template.html
@@ -81,7 +81,7 @@
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
     <!-- LOGO -->
     <tr>
-        <td align="center" bgcolor="#530EEC">
+        <td align="center" bgcolor="{{ UI.SECONDARY }}">
             <!--[if (gte mso 9)|(IE)]>
             <table align="center" border="0" cellspacing="0" cellpadding="0" width="600">
                 <tr>
@@ -91,9 +91,9 @@
                 <tr>
                     <td align="center" style="padding: 40px 10px 40px 10px;" valign="top">
                         <a href="{{ args.home_url }}" target="_blank">
-                            <img alt="Logo" border="0" height="44" src="https://i.imgur.com/t0DPkyl.png"
-                                 style="display: block; width: 150px; max-width: 150px; min-width: 150px; font-family: 'Nunito Sans', Helvetica, Arial, sans-serif; color: #ffffff; font-size: 18px;"
-                                 width="120">
+                            <img alt="Logo" border="0" height="44" src="https://i.imgur.com/WIuJxYB.png"
+                                 style="display: block; width: 180px; max-width: 180px; min-width: 180px; font-family: 'Nunito Sans', Helvetica, Arial, sans-serif; color: #ffffff; font-size: 18px;"
+                                 width="180">
                         </a>
                     </td>
                 </tr>
@@ -107,7 +107,7 @@
     </tr>
     <!-- TITLE -->
     <tr>
-        <td align="center" bgcolor="#530EEC" style="padding: 0px 10px 0px 10px;">
+        <td align="center" bgcolor="{{ UI.SECONDARY }}" style="padding: 0px 10px 0px 10px;">
             <!--[if (gte mso 9)|(IE)]>
             <table align="center" border="0" cellspacing="0" cellpadding="0" width="600">
                 <tr>
@@ -167,7 +167,9 @@
                     <td align="center" bgcolor="#f4f4f4"
                         style="padding: 30px 30px 30px 30px; color: #666666; font-family: 'Nunito Sans', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 400; line-height: 18px;">
                         <p style="margin: 0;">
-                            <a href="{{ args.home_url }}" style="color: #221F1F; font-weight: 700;" target="_blank">Grant.io</a>
+                            <a href="{{ args.home_url }}" style="color: #221F1F; font-weight: 700;" target="_blank">
+                                {{ UI.NAME }}
+                            </a>
                             -
                             <a href="{{ args.account_url }}" style="color: #221F1F; font-weight: 700;" target="_blank">Your
                                 Account</a> -
@@ -195,7 +197,7 @@
                     <td align="center" bgcolor="#f4f4f4"
                         style="padding: 0px 30px 30px 30px; color: #AAAAAA; font-family: 'Nunito Sans', Helvetica, Arial, sans-serif; font-size: 12px; font-weight: 400; line-height: 18px;">
                         <p style="margin: 0;">
-                            Grant.io Inc, 123 Address Street, Somewhere, NY 11211
+                            Zcash Foundation, 123 Address Street, Somewhere, NY 11211
                         </p>
                     </td>
                 </tr>

--- a/backend/grant/templates/emails/template.txt
+++ b/backend/grant/templates/emails/template.txt
@@ -2,8 +2,8 @@
 
 ===============
 
-Grant.io
+{{ UI.NAME }}
 123 Address Street
 City, ST 12345
 
-Unsubscribe here: https://grant.io/unsubscribe
+Unsubscribe here: {{ args.unsubscribe_url }}

--- a/backend/tests/test_data.py
+++ b/backend/tests/test_data.py
@@ -2,47 +2,6 @@ import random
 
 from grant.proposal.models import CATEGORIES
 
-message = {
-    "sig": "0x7b3a85e9f158c2ae2a9ffba986a7dcb9108cf8ea9691080f80eadb506719f14925c89777aade3fabc5f9730ea389abdf7ffb0da16babdf1a1ea710b1e998cb891c",
-    "data": {
-        "domain": {
-            "name": "Grant.io",
-            "version": 1,
-            "chainId": 1543277948575
-        },
-        "types": {
-            "authorization": [
-                {
-                    "name": "Message Proof",
-                    "type": "string"
-                },
-                {
-                    "name": "Time",
-                    "type": "string"
-                }
-            ],
-            "EIP712Domain": [
-                {
-                    "name": "name",
-                    "type": "string"
-                },
-                {
-                    "name": "version",
-                    "type": "string"
-                },
-                {
-                    "name": "chainId",
-                    "type": "uint256"
-                }
-            ]
-        },
-        "message": {
-            "message": "I am proving the identity of 0x6bEeA1Cef016c23e292381b6FcaeC092960e41aa on Grant.io",
-            "time": "Tue, 27 Nov 2018 19:02:04 GMT"
-        },
-        "primaryType": "authorization"
-    }
-}
 
 test_user = {
     "displayName": 'Groot',


### PR DESCRIPTION
Closes #104. Based off of #105 to prevent conflicts and incorporate its emails.

Changes the branding of emails, some strings on the backend, and admin with ZF Grants. Uses variables in most places for easy changes going forward.

<img width="679" alt="screen shot 2019-01-24 at 3 18 00 pm" src="https://user-images.githubusercontent.com/649992/51706658-27fb4680-1fed-11e9-8a2b-98f1be225278.png">
