### PR TITLE
Require email verification before important actions

### DIFF
--- a/backend/grant/user/models.py
+++ b/backend/grant/user/models.py
@@ -248,9 +248,29 @@ class SelfUserSchema(ma.Schema):
 self_user_schema = SelfUserSchema()
 self_users_schema = SelfUserSchema(many=True)
 
-user_schema = SelfUserSchema(exclude=['email_address'])
-users_schema = SelfUserSchema(many=True, exclude=['email_address'])
 
+class UserSchema(ma.Schema):
+    class Meta:
+        model = User
+        # Fields to expose
+        fields = (
+            "title",
+            "social_medias",
+            "avatar",
+            "display_name",
+            "userid"
+        )
+
+    social_medias = ma.Nested("SocialMediaSchema", many=True)
+    avatar = ma.Nested("AvatarSchema")
+    userid = ma.Method("get_userid")
+
+    def get_userid(self, obj):
+        return obj.id
+
+
+user_schema = SelfUserSchema()
+users_schema = SelfUserSchema(many=True)
 
 class SocialMediaSchema(ma.Schema):
     class Meta:

--- a/frontend/client/components/Proposal/Comments/index.tsx
+++ b/frontend/client/components/Proposal/Comments/index.tsx
@@ -68,7 +68,7 @@ class ProposalComments extends React.Component<Props, State> {
     }
 
     if (postCommentError && postCommentError !== prevProps.postCommentError) {
-      message.error('Failed to submit comment');
+      message.error(postCommentError);
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/grant-project/zcash-grant-system/issues/47

Builds on https://github.com/grant-project/zcash-grant-system/pull/113

### What this does
This PR includes validation to prevent proposal submissions and comments before a user's email address has been verified.

### What could be better?
`validate_publishable` seems to get called at various points in the proposal lifecycle, but the email check is only done once. I'd love some eyes on my changes to it.

##### Proposal Validation
<img width="1440" alt="screen shot 2019-01-27 at 7 56 37 pm" src="https://user-images.githubusercontent.com/7861465/51810692-090be700-226f-11e9-9aa4-dd54a80f2c61.png">
##### Comment Validation
<img width="1440" alt="screen shot 2019-01-27 at 7 53 07 pm" src="https://user-images.githubusercontent.com/7861465/51810693-09a47d80-226f-11e9-9513-c70892378070.png">

