### PR TITLE
Enforce email verification server side

### DIFF
--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -7,7 +7,13 @@ from grant.milestone.models import Milestone
 from grant.settings import EXPLORER_URL, PROPOSAL_STAKING_AMOUNT
 from grant.user.models import User
 from grant.rfp.models import RFP
-from grant.utils.auth import requires_auth, requires_team_member_auth, get_authed_user, internal_webhook
+from grant.utils.auth import (
+    requires_auth,
+    requires_team_member_auth,
+    requires_email_verified_auth,
+    get_authed_user,
+    internal_webhook
+)
 from grant.utils.exceptions import ValidationException
 from grant.utils.misc import is_email, make_url, from_zat, make_preview
 from grant.utils.enums import ProposalStatus, ContributionStatus
@@ -66,7 +72,7 @@ def get_proposal_comments(proposal_id):
 
 
 @blueprint.route("/<proposal_id>/comments", methods=["POST"])
-@requires_auth
+@requires_email_verified_auth
 @endpoint.api(
     parameter('comment', type=str, required=True),
     parameter('parentCommentId', type=int, required=False)
@@ -146,7 +152,7 @@ def get_proposals(stage):
 
 
 @blueprint.route("/drafts", methods=["POST"])
-@requires_auth
+@requires_email_verified_auth
 @endpoint.api(
     parameter('rfpId', type=int),
 )

--- a/backend/grant/utils/auth.py
+++ b/backend/grant/utils/auth.py
@@ -46,6 +46,16 @@ def requires_same_user_auth(f):
     return requires_auth(decorated)
 
 
+def requires_email_verified_auth(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if not g.current_user.email_verification.has_verified:
+            return jsonify(message="Please confirm your email."), 403
+        return f(*args, **kwargs)
+
+    return requires_auth(decorated)
+
+
 def requires_team_member_auth(f):
     @wraps(f)
     def decorated(*args, **kwargs):
@@ -60,13 +70,10 @@ def requires_team_member_auth(f):
         if g.current_user not in proposal.team:
             return jsonify(message="You are not authorized to modify this proposal"), 403
 
-        if not g.current_user.email_verification.has_verified:
-            return jsonify(message="Please confirm your email."), 403
-
         g.current_proposal = proposal
         return f(*args, **kwargs)
 
-    return requires_auth(decorated)
+    return requires_email_verified_auth(decorated)
 
 
 def internal_webhook(f):

--- a/backend/tests/proposal/test_comment_api.py
+++ b/backend/tests/proposal/test_comment_api.py
@@ -110,4 +110,4 @@ class TestProposalCommentAPI(BaseUserConfig):
             content_type='application/json'
         )
 
-        self.assertStatus(comment_res, 401)
+        self.assertStatus(comment_res, 403)


### PR DESCRIPTION
Fixes a small issue where you could create drafts as a unverified user, but edits were rejected. Adds a new middleware for ensuring user is both auth'd and has verified email. Adds it to POST drafts and POST comment.