### PR TITLE
No previews in emails

### DIFF
--- a/backend/grant/admin/example_emails.py
+++ b/backend/grant/admin/example_emails.py
@@ -80,7 +80,6 @@ example_email_args = {
     'proposal_comment': {
         'author': user,
         'proposal': proposal,
-        'preview': 'Blah blah blah blah blah...',
         'comment_url': 'http://somecomment.com',
         'author_url': 'http://someuser.com',
     },
@@ -92,13 +91,11 @@ example_email_args = {
     'contribution_update': {
         'proposal': proposal,
         'proposal_update': update,
-        'preview': 'Blah blah blah blah blah blah blah blah blah blah blah blah blah blah...',
         'update_url': 'http://someupdate.com',
     },
     'comment_reply': {
         'author': user,
         'proposal': proposal,
-        'preview': 'Blah blah blah blah blah...',
         'comment_url': 'http://somecomment.com',
         'author_url': 'http://someuser.com',
     },

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -15,7 +15,7 @@ from grant.utils.auth import (
     internal_webhook
 )
 from grant.utils.exceptions import ValidationException
-from grant.utils.misc import is_email, make_url, from_zat, make_preview
+from grant.utils.misc import is_email, make_url, from_zat
 from grant.utils.enums import ProposalStatus, ContributionStatus
 from sqlalchemy import or_
 
@@ -107,13 +107,11 @@ def post_proposal_comments(proposal_id, comment, parent_comment_id):
     dumped_comment = comment_schema.dump(comment)
 
     # TODO: Email proposal team if top-level comment
-    preview = make_preview(comment.content, 60)
     if not parent:
         for member in proposal.team:
             send_email(member.email_address, 'proposal_comment', {
                 'author': g.current_user,
                 'proposal': proposal,
-                'preview': preview,
                 'comment_url': make_url(f'/proposal/{proposal.id}?tab=discussions&comment={comment.id}'),
                 'author_url': make_url(f'/profile/{comment.author.id}'),
             })
@@ -122,7 +120,6 @@ def post_proposal_comments(proposal_id, comment, parent_comment_id):
         send_email(parent.author.email_address, 'comment_reply', {
             'author': g.current_user,
             'proposal': proposal,
-            'preview': preview,
             'comment_url': make_url(f'/proposal/{proposal.id}?tab=discussions&comment={comment.id}'),
             'author_url': make_url(f'/profile/{comment.author.id}'),
         })
@@ -328,13 +325,11 @@ def post_proposal_update(proposal_id, title, content):
     db.session.commit()
 
     # Send email to all contributors (even if contribution failed)
-    preview = make_preview(update.content, 200)
     contributions = ProposalContribution.query.filter_by(proposal_id=proposal_id).all()
     for c in contributions:
         send_email(c.user.email_address, 'contribution_update', {
             'proposal': g.current_proposal,
             'proposal_update': update,
-            'preview': preview,
             'update_url': make_url(f'/proposals/{proposal_id}?tab=updates&update={update.id}'),
         })
 

--- a/backend/grant/templates/emails/comment_reply.html
+++ b/backend/grant/templates/emails/comment_reply.html
@@ -1,11 +1,7 @@
 <p style="margin: 0 0 20px;">
     You just received a reply from
     <a href="{{ args.author_url }}" target="_blank">{{ args.author.display_name }}</a>
-    on <strong>{{ args.proposal.title }}</strong>:
-</p>
-
-<p style="margin: 10px 0; padding: 20px; background: #F8F8F8;">
-    “{{ args.preview }}”
+    on <strong>{{ args.proposal.title }}</strong>.
 </p>
 
 <table width="100%" border="0" cellspacing="0" cellpadding="0">

--- a/backend/grant/templates/emails/comment_reply.txt
+++ b/backend/grant/templates/emails/comment_reply.txt
@@ -1,6 +1,4 @@
 You just received a reply from {{ args.author.display_name }} on {{ args.proposal.title }}:
 
-> {{ args.preview }}
-
 Go here to see their response: {{ args.comment_url }}
 Go here to see their profile: {{ args.author_url }}

--- a/backend/grant/templates/emails/contribution_update.html
+++ b/backend/grant/templates/emails/contribution_update.html
@@ -1,14 +1,7 @@
-<p style="margin: 0;">
+<p style="margin: 0 0 20px;">
     A proposal you follow, <strong>{{ args.proposal.title }}</strong>, has
-    posted an update:
+    posted an update entitled "<strong>{{ args.proposal_update.title }}</strong>"
 </p>
-
-<div style="margin: 10px 0; padding: 20px; background: #F8F8F8;">
-    <h2 style="margin: 0 0 20px 0; font-size: 20px; font-weight: bold;">
-        {{ args.proposal_update.title }}
-    </h2>
-    <p style="margin: 0;">{{ args.preview }}</p>
-</div>
 
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
     <tr>
@@ -17,11 +10,11 @@
                 <tr>
                     <td align="center" style="border-radius: 3px;" bgcolor="{{ UI.PRIMARY }}">
                         <a
-                                href="{{ args.update_url }}"
-                                target="_blank"
-                                style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{ UI.PRIMARY }}; display: inline-block;"
+                            href="{{ args.update_url }}"
+                            target="_blank"
+                            style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{ UI.PRIMARY }}; display: inline-block;"
                         >
-                            View the full update
+                            Read the Update
                         </a>
                     </td>
                 </tr>
@@ -29,4 +22,3 @@
         </td>
     </tr>
 </table>
-  

--- a/backend/grant/templates/emails/contribution_update.txt
+++ b/backend/grant/templates/emails/contribution_update.txt
@@ -1,2 +1,4 @@
-A proposal you follow, "{{ args.proposal.title }}", has posted an update.
-Go here to view it in full: {{ args.update_url }}
+A proposal you follow, "{{ args.proposal.title }}", has posted an update
+entitled "{{ args.proposal_update.title }}".
+
+Go here to read it: {{ args.update_url }}

--- a/backend/grant/templates/emails/proposal_comment.html
+++ b/backend/grant/templates/emails/proposal_comment.html
@@ -1,10 +1,6 @@
 <p style="margin: 0 0 20px;">
     Your proposal <strong>{{ args.proposal.title }}</strong> just received a comment from
-    <a href="{{ args.author_url }}" target="_blank">{{ args.author.display_name }}</a>:
-</p>
-
-<p style="margin: 10px 0; padding: 20px; background: #F8F8F8;">
-    “{{ args.preview }}”
+    <a href="{{ args.author_url }}" target="_blank">{{ args.author.display_name }}</a>.
 </p>
 
 <table width="100%" border="0" cellspacing="0" cellpadding="0">

--- a/backend/grant/templates/emails/proposal_comment.txt
+++ b/backend/grant/templates/emails/proposal_comment.txt
@@ -1,6 +1,4 @@
-Your proposal "{{ args.proposal.title }}" just received a comment from {{ args.author.display_name }}:
-
-> {{ args.preview }}
+Your proposal "{{ args.proposal.title }}" just received a comment from {{ args.author.display_name }}.
 
 Go here to see their comment: {{ args.comment_url }}
 Go here to see their profile: {{ args.author_url }}


### PR DESCRIPTION
Closes #109. Simply removes previews from comment and update emails. Due to the complexity and mismatch of python markdown libraries as compared with our frontend one, and the potential security implications since comments are posted before moderation, it's just easier to chop this Gordian knot and not include user content in emails.