### PR TITLE
GDPR and Cookie Compliance

### DIFF
--- a/admin/src/components/UserDetail/index.tsx
+++ b/admin/src/components/UserDetail/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { view } from 'react-easy-state';
 import { RouteComponentProps, withRouter } from 'react-router';
-import { Row, Col, Card, Button, Collapse, Popconfirm, Avatar, List } from 'antd';
+import { Row, Col, Card, Button, Collapse, Popconfirm, Avatar, List, message } from 'antd';
 import TextArea from 'antd/lib/input/TextArea';
 import store from 'src/store';
 import { Proposal, Comment, Contribution } from 'src/types';
@@ -20,9 +20,11 @@ type State = typeof STATE;
 class UserDetailNaked extends React.Component<Props, State> {
   state = STATE;
   rejectInput: null | TextArea = null;
+
   componentDidMount() {
     this.loadDetail();
   }
+  
   render() {
     const id = this.getIdFromQuery();
     const { userDetail: u, userDetailFetching } = store;
@@ -34,11 +36,16 @@ class UserDetailNaked extends React.Component<Props, State> {
     const renderDelete = () => (
       <Popconfirm
         onConfirm={this.handleDelete}
-        title="Delete user?"
-        okText="delete"
-        cancelText="cancel"
+        title={<>
+          Are you sure? Due to GDPR compliance,
+          <br/>
+          this <strong>cannot</strong> be undone.
+        </>}
+        okText="Delete"
+        cancelText="Cancel"
+        okType="danger"
       >
-        <Button icon="delete" block>
+        <Button icon="delete" type="danger" ghost block>
           Delete
         </Button>
       </Popconfirm>
@@ -197,9 +204,13 @@ class UserDetailNaked extends React.Component<Props, State> {
     store.fetchUserDetail(this.getIdFromQuery());
   };
 
-  private handleDelete = () => {
+  private handleDelete = async () => {
     if (!store.userDetail) return;
-    store.deleteUser(store.userDetail.userid);
+    await store.deleteUser(store.userDetail.userid);
+    if (store.userDeleted) {
+      message.success('Successfully deleted', 2);
+      this.props.history.replace('/users');
+    }
   };
 }
 

--- a/admin/src/components/Users/UserItem.tsx
+++ b/admin/src/components/Users/UserItem.tsx
@@ -1,27 +1,14 @@
 import React from 'react';
 import { view } from 'react-easy-state';
-import { Popconfirm, List, Avatar } from 'antd';
+import { List, Avatar } from 'antd';
 import { Link } from 'react-router-dom';
-import store from 'src/store';
 import { User } from 'src/types';
 import './UserItem.less';
 
 class UserItemNaked extends React.Component<User> {
   render() {
     const p = this.props;
-
-    const deleteAction = (
-      <Popconfirm
-        onConfirm={this.handleDelete}
-        title="Are you sure?"
-        okText="delete"
-        cancelText="cancel"
-      >
-        <div>delete</div>
-      </Popconfirm>
-    );
-    const viewAction = <Link to={`/users/${p.userid}`}>view</Link>;
-    const actions = [viewAction, deleteAction];
+    const actions = [<Link to={`/users/${p.userid}`} key="view">view</Link>];
 
     return (
       <List.Item key={p.userid} className="UserItem" actions={actions}>
@@ -39,9 +26,6 @@ class UserItemNaked extends React.Component<User> {
       </List.Item>
     );
   }
-  private handleDelete = () => {
-    store.deleteUser(this.props.userid);
-  };
 }
 
 const UserItem = view(UserItemNaked);

--- a/admin/src/store.ts
+++ b/admin/src/store.ts
@@ -41,7 +41,7 @@ async function fetchUserDetail(id: number) {
   return data;
 }
 
-async function deleteUser(id: number | string) {
+async function deleteUser(id: number) {
   const { data } = await api.delete('/admin/users/' + id);
   return data;
 }
@@ -119,6 +119,8 @@ const app = store({
   users: [] as User[],
   userDetailFetching: false,
   userDetail: null as null | User,
+  userDeleting: false,
+  userDeleted: false,
 
   proposalsFetching: false,
   proposalsFetched: false,
@@ -204,13 +206,18 @@ const app = store({
     app.userDetailFetching = false;
   },
 
-  async deleteUser(id: string | number) {
+  async deleteUser(id: number) {
+    app.userDeleting = false;
+    app.userDeleted = false;
     try {
       await deleteUser(id);
-      app.users = app.users.filter(u => u.userid !== id && u.emailAddress !== id);
+      app.users = app.users.filter(u => u.userid !== id);
+      app.userDeleted = true;
+      app.userDetail = null;
     } catch (e) {
       handleApiError(e);
     }
+    app.userDeleting = false;
   },
 
   async fetchProposals(statusFilters?: PROPOSAL_STATUS[]) {

--- a/backend/grant/admin/views.py
+++ b/backend/grant/admin/views.py
@@ -66,11 +66,17 @@ def stats():
 # USERS
 
 
-@blueprint.route('/users/<id>', methods=['DELETE'])
+@blueprint.route('/users/<user_id>', methods=['DELETE'])
 @endpoint.api()
 @admin_auth_required
-def delete_user(id):
-    return {"message": "Not implemented."}, 400
+def delete_user(user_id):
+    user = User.query.filter(User.id == user_id).first()
+    if not user:
+        return {"message": "No user matching that id"}, 404
+
+    db.session.delete(user)
+    db.session.commit()
+    return None, 200
 
 
 @blueprint.route("/users", methods=["GET"])

--- a/frontend/client/components/AuthFlow/SignUp.less
+++ b/frontend/client/components/AuthFlow/SignUp.less
@@ -19,5 +19,24 @@
     &-alert {
       margin-top: 1rem;
     }
+
+    &-legal {
+      display: block;
+      margin-bottom: 1rem;
+
+      &-text {
+        font-size: 0.75rem;
+        line-height: 1.2rem;
+        opacity: 0.8;
+      }
+
+      .ant-form-item-control {
+        line-height: inherit;
+      }
+    }
+
+    .PasswordFormItems .ant-row {
+      margin-bottom: 0.75rem;
+    }
   }
 }

--- a/frontend/client/components/AuthFlow/SignUp.tsx
+++ b/frontend/client/components/AuthFlow/SignUp.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Form, Input, Button, Alert } from 'antd';
+import { Form, Input, Button, Checkbox, Alert } from 'antd';
 import { FormComponentProps } from 'antd/lib/form';
 import { authActions } from 'modules/auth';
 import { AppState } from 'store/reducers';
 import PasswordFormItems from 'components/PasswordFormItems';
 import './SignUp.less';
+import { Link } from 'react-router-dom';
 
 interface StateProps {
   isCreatingUser: AppState['auth']['isCreatingUser'];
@@ -66,6 +67,32 @@ class SignUp extends React.Component<Props> {
             </Form.Item>
 
             <PasswordFormItems form={this.props.form} />
+
+            <Form.Item className="SignUp-form-legal">
+              {getFieldDecorator('hasAgreed', {
+                rules: [
+                  { required: true, message: 'You must agree to create an account' },
+                ],
+              })(
+                <Checkbox name="hasAgreed">
+                  <span className="SignUp-form-legal-text">
+                    I agree to the{' '}
+                    <Link target="_blank" to="/code-of-conduct">
+                      code of conduct
+                    </Link>
+                    ,{' '}
+                    <Link target="_blank" to="/tos">
+                      terms of service
+                    </Link>
+                    , and{' '}
+                    <Link target="_blank" to="/privacy">
+                      privacy policy
+                    </Link>
+                    .
+                  </span>
+                </Checkbox>,
+              )}
+            </Form.Item>
 
             <div className="SignUp-form-controls">
               <Button

--- a/frontend/client/index.tsx
+++ b/frontend/client/index.tsx
@@ -4,7 +4,6 @@ import { hot } from 'react-hot-loader';
 import { hydrate } from 'react-dom';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import { PersistGate } from 'redux-persist/integration/react';
 import * as Sentry from '@sentry/browser';
 import { I18nextProvider } from 'react-i18next';
 import { loadableReady } from '@loadable/component';
@@ -21,7 +20,7 @@ Sentry.init({
 });
 const initialState =
   window && massageSerializedState((window as any).__PRELOADED_STATE__);
-const { store, persistor } = configureStore(initialState);
+const { store } = configureStore(initialState);
 const i18nLanguage = window && (window as any).__PRELOADED_I18N__;
 i18n.changeLanguage(i18nLanguage.locale);
 i18n.addResourceBundle(i18nLanguage.locale, 'common', i18nLanguage.resources, true);
@@ -29,11 +28,9 @@ i18n.addResourceBundle(i18nLanguage.locale, 'common', i18nLanguage.resources, tr
 const App = hot(module)(() => (
   <I18nextProvider i18n={i18n}>
     <Provider store={store}>
-      <PersistGate persistor={persistor}>
-        <Router history={history}>
-          <Routes />
-        </Router>
-      </PersistGate>
+      <Router history={history}>
+        <Routes />
+      </Router>
     </Provider>
   </I18nextProvider>
 ));

--- a/frontend/client/modules/auth/index.ts
+++ b/frontend/client/modules/auth/index.ts
@@ -3,8 +3,6 @@ import * as authActions from './actions';
 import * as authTypes from './types';
 import authSagas from './sagas';
 
-export * from './persistence';
-
 export { authActions, authTypes, authSagas, AuthState, INITIAL_STATE };
 
 export default reducers;

--- a/frontend/client/modules/auth/persistence.ts
+++ b/frontend/client/modules/auth/persistence.ts
@@ -1,9 +1,0 @@
-import { PersistConfig } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
-
-export const authPersistConfig: PersistConfig = {
-  key: 'auth',
-  storage,
-  version: 1,
-  whitelist: ['authSignature', 'authSignatureAddress'],
-};

--- a/frontend/client/store/configure.tsx
+++ b/frontend/client/store/configure.tsx
@@ -3,7 +3,6 @@ import createSagaMiddleware, { SagaMiddleware } from 'redux-saga';
 import thunkMiddleware, { ThunkMiddleware } from 'redux-thunk';
 import promiseMiddleware from 'redux-promise-middleware';
 import { composeWithDevTools } from 'redux-devtools-extension';
-import { persistStore, Persistor } from 'redux-persist';
 import { routerMiddleware } from 'connected-react-router';
 import rootReducer, { AppState, combineInitialState } from './reducers';
 import rootSaga from './sagas';
@@ -35,10 +34,6 @@ export function configureStore(initialState: Partial<AppState> = combineInitialS
       routerMiddleware(history),
     ]),
   );
-  // Don't persist server side, but don't mess up types for client side
-  const persistor: Persistor = process.env.SERVER_SIDE_RENDER
-    ? (undefined as any)
-    : persistStore(store);
 
   sagaMiddleware.run(rootSaga);
 
@@ -50,5 +45,5 @@ export function configureStore(initialState: Partial<AppState> = combineInitialS
     }
   }
 
-  return { store, persistor };
+  return { store };
 }

--- a/frontend/client/store/reducers.tsx
+++ b/frontend/client/store/reducers.tsx
@@ -1,16 +1,11 @@
-import { combineReducers, Reducer } from 'redux';
+import { combineReducers } from 'redux';
 import { connectRouter, RouterState } from 'connected-react-router';
-import { persistReducer } from 'redux-persist';
 import proposal, {
   ProposalState,
   INITIAL_STATE as proposalInitialState,
 } from 'modules/proposals';
 import create, { CreateState, INITIAL_STATE as createInitialState } from 'modules/create';
-import authReducer, {
-  AuthState,
-  INITIAL_STATE as authInitialState,
-  authPersistConfig,
-} from 'modules/auth';
+import auth, { AuthState, INITIAL_STATE as authInitialState } from 'modules/auth';
 import users, { UsersState, INITIAL_STATE as usersInitialState } from 'modules/users';
 import rfps, { RFPState, INITIAL_STATE as rfpsInitialState } from 'modules/rfps';
 import history from './history';
@@ -37,7 +32,6 @@ export default combineReducers<AppState>({
   create,
   users,
   rfps,
-  // Don't allow for redux-persist's _persist key to be touched in our code
-  auth: (persistReducer(authPersistConfig, authReducer) as any) as Reducer<AuthState>,
+  auth,
   router: connectRouter(history),
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -137,7 +137,6 @@
     "redux": "^4.0.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-logger": "^3.0.6",
-    "redux-persist": "5.10.0",
     "redux-promise-middleware": "^5.1.1",
     "redux-saga": "^0.16.0",
     "redux-thunk": "^2.3.0",


### PR DESCRIPTION
Closes #106.

### What This Does

To be compliant with GDPR and cookie laws, we have the following changes:

* Signup now requires explicit consent to the code of conduct, ToS, and privacy policy.
    * Privacy policy will require a section on cookie usage to be fully compliant
    * Code of conduct isn't a legal requirement, but seemed like a good idea to highlight during signup
    * If the ZF team wants to use user emails for anything other than the grants site, we'll need to add another checkbox asking for explicit consent to do that.
* Adds the ability to delete users in the admin
    * Unlike other forms of delete which would just flip a status to `DELETED`, this will actually purge the system of the account
    * We may need to figure out some kind of db backup purging for #143, or exclude users from backups.
* Removes the unused `redux-persist` since we switch to cookie-based auth
    * Since user is only given cookies at signup, this removes the need for a notification due to having to agree to privacy policy. If there's ever a need for pre-auth local storage or cookies, we'll need to add a notification on visit.

### Steps to Test

* Sign up as a new user, confirm that you cannot signup without agreeing to legal stuff
* Confirm sign in / sign out persistence still works as expected
* Confirm you can delete the user in the admin, and that it completely removes them