### PR TITLE
Add create-proposals script to README

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -89,6 +89,11 @@ To create a proposal, run
 
     flask create_proposal "FUNDING_REQUIRED" 1 123 "My Awesome Proposal" "### Hi! I have a great proposal"
 
+To seed many proposals, run
+
+    flask create_proposals <number_of_proposals:int>
+
+
 ## S3 Storage Setup
 
 1. create bucket, keep the `bucket name` and `region` handy

--- a/backend/README.md
+++ b/backend/README.md
@@ -87,11 +87,11 @@ For a full migration command reference, run `flask db --help`.
 
 To create a proposal, run
 
-    flask create_proposal "FUNDING_REQUIRED" 1 123 "My Awesome Proposal" "### Hi! I have a great proposal"
+    flask create-proposal "FUNDING_REQUIRED" 1 123 "My Awesome Proposal" "### Hi! I have a great proposal"
 
 To seed many proposals, run
 
-    flask create_proposals <number_of_proposals:int>
+    flask create-proposals <number_of_proposals:int>
 
 
 ## S3 Storage Setup


### PR DESCRIPTION
Pretty simple, just adds an example and documents `create-proposals`, a flask CLI command that lets you create X number of fake proposals (for testing).