### PR TITLE
Fix Milestone Estimated Date Parser

### DIFF
--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -19,6 +19,7 @@ from grant.utils.misc import is_email, make_url, from_zat
 from grant.utils.enums import ProposalStatus, ContributionStatus
 from grant.utils import pagination
 from sqlalchemy import or_
+import datetime
 
 from .models import (
     Proposal,
@@ -216,7 +217,7 @@ def update_proposal(milestones, proposal_id, **kwargs):
             m = Milestone(
                 title=mdata["title"],
                 content=mdata["content"],
-                date_estimated=parse(mdata["dateEstimated"]),
+                date_estimated=datetime.datetime.fromtimestamp(mdata["dateEstimated"]),
                 payout_percent=str(mdata["payoutPercent"]),
                 immediate_payout=mdata["immediatePayout"],
                 proposal_id=g.current_proposal.id

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -19,7 +19,7 @@ from grant.utils.misc import is_email, make_url, from_zat
 from grant.utils.enums import ProposalStatus, ContributionStatus
 from grant.utils import pagination
 from sqlalchemy import or_
-import datetime
+from datetime import datetime
 
 from .models import (
     Proposal,
@@ -217,7 +217,7 @@ def update_proposal(milestones, proposal_id, **kwargs):
             m = Milestone(
                 title=mdata["title"],
                 content=mdata["content"],
-                date_estimated=datetime.datetime.fromtimestamp(mdata["dateEstimated"]),
+                date_estimated=datetime.fromtimestamp(mdata["dateEstimated"]),
                 payout_percent=str(mdata["payoutPercent"]),
                 immediate_payout=mdata["immediatePayout"],
                 proposal_id=g.current_proposal.id

--- a/backend/tests/test_data.py
+++ b/backend/tests/test_data.py
@@ -31,7 +31,7 @@ milestones = [
     {
         "title": "All the money straightaway",
         "content": "cool stuff with it",
-        "dateEstimated": "Fri, 30 Nov 2018 01:42:23 GMT",
+        "dateEstimated": 1549505307,
         "payoutPercent": "100",
         "immediatePayout": False
     }


### PR DESCRIPTION
Uses `datetime`'s `fromtimestamp` instead of `dateutils`'s `parse` to parse milestone estimated dates.

As far as I can tell, the backend is expecting human readable dates passed in the API ala `"Fri, 30 Nov 2018 01:42:23 GMT"`, but the FE is sending unix timestamps (`1549505307`).

This PR adjusts the backend API to behave with the expectation of unix timestamps. 

`fromtimestamp` correctly handles parsing unix timestamps (int), wheras `parse` expects the human readable date that's not being sent:

``` 
Parser must be a string or character stream, not int
```