### PR TITLE
Remove comments option from updates

### DIFF
--- a/frontend/client/components/Proposal/Updates/index.tsx
+++ b/frontend/client/components/Proposal/Updates/index.tsx
@@ -82,9 +82,6 @@ class ProposalUpdates extends React.Component<Props, State> {
             </div>
             <div className="ProposalUpdates-update-controls">
               <a className="ProposalUpdates-update-controls-button">Read more</a>
-              <a className="ProposalUpdates-update-controls-button">
-                {update.totalComments} comments
-              </a>
             </div>
           </div>
         ));

--- a/frontend/types/update.ts
+++ b/frontend/types/update.ts
@@ -3,5 +3,4 @@ export interface Update {
   title: string;
   content: string;
   dateCreated: number;
-  totalComments: number;
 }


### PR DESCRIPTION
Closes https://github.com/grant-project/zcash-grant-system/issues/139

Pretty simple, just removes the unused comments option on updates.

The API doesn't even provide `totalComments`, so I removed it from the type definition as well. 