### PR TITLE
Resend email verification

### DIFF
--- a/backend/grant/user/models.py
+++ b/backend/grant/user/models.py
@@ -156,10 +156,7 @@ class User(db.Model, UserMixin):
         db.session.commit()
 
         if _send_email:
-            send_email(user.email_address, 'signup', {
-                'display_name': user.display_name,
-                'confirm_url': make_url(f'/email/verify?code={ev.code}')
-            })
+            user.send_verification_email()
 
         return user
 
@@ -211,6 +208,12 @@ class User(db.Model, UserMixin):
 
     def login(self):
         login_user(self)
+
+    def send_verification_email(self):
+        send_email(self.email_address, 'signup', {
+            'display_name': self.display_name,
+            'confirm_url': make_url(f'/email/verify?code={self.email_verification.code}')
+        })
 
     def send_recovery_email(self):
         existing = self.email_recovery

--- a/backend/grant/user/views.py
+++ b/backend/grant/user/views.py
@@ -170,8 +170,15 @@ def update_user_password(current_password, password):
 def update_user_email(email, password):
     if not g.current_user.check_password(password):
         return {"message": "Password is incorrect"}, 403
-    print('set_email')
     g.current_user.set_email(email)
+    return None, 200
+
+
+@blueprint.route("/me/resend-verification", methods=["PUT"])
+@requires_auth
+@endpoint.api()
+def resend_email_verification():
+    g.current_user.send_verification_email()
     return None, 200
 
 

--- a/frontend/client/api/api.ts
+++ b/frontend/client/api/api.ts
@@ -294,3 +294,7 @@ export function getRFP(rfpId: number | string): Promise<{ data: RFP }> {
     return res;
   });
 }
+
+export function resendEmailVerification(): Promise<{ data: void }> {
+  return axios.put(`/api/v1/users/me/resend-verification`);
+}

--- a/frontend/client/components/Settings/Account.less
+++ b/frontend/client/components/Settings/Account.less
@@ -1,5 +1,10 @@
 .AccountSettings {
   &-form {
+    &-resend {
+      position: relative;
+      margin-bottom: 1rem;
+    }
+
     & > .ant-form-item {
       margin-bottom: 0.75rem;
     }


### PR DESCRIPTION
Closes #146.

### What This Does

Adds an alert to the account settings tab when your email isn't verified to resend. I didn't touch the existing email blockers since they're subject to change. If we don't end up changing, we can just link to /settings?tab=account.

## Screenshots

<img width="832" alt="screen shot 2019-02-08 at 2 57 39 pm" src="https://user-images.githubusercontent.com/649992/52503667-36805b00-2bb4-11e9-89ea-addab78d15c6.png">

<img width="857" alt="screen shot 2019-02-08 at 2 54 01 pm" src="https://user-images.githubusercontent.com/649992/52503676-384a1e80-2bb4-11e9-9fcd-c4eb066d4152.png">
