### PR TITLE
Finalize Categories

### DIFF
--- a/backend/grant/utils/enums.py
+++ b/backend/grant/utils/enums.py
@@ -41,7 +41,6 @@ ProposalStage = ProposalStageEnum()
 
 
 class CategoryEnum(CustomEnum):
-    DAPP = 'DAPP'
     DEV_TOOL = 'DEV_TOOL'
     CORE_DEV = 'CORE_DEV'
     COMMUNITY = 'COMMUNITY'

--- a/frontend/client/api/constants.ts
+++ b/frontend/client/api/constants.ts
@@ -9,7 +9,6 @@ export const SORT_LABELS: { [key in PROPOSAL_SORT]: string } = {
 };
 
 export enum PROPOSAL_CATEGORY {
-  DAPP = 'DAPP',
   DEV_TOOL = 'DEV_TOOL',
   CORE_DEV = 'CORE_DEV',
   COMMUNITY = 'COMMUNITY',
@@ -24,11 +23,6 @@ interface CategoryUI {
 }
 
 export const CATEGORY_UI: { [key in PROPOSAL_CATEGORY]: CategoryUI } = {
-  DAPP: {
-    label: 'DApp',
-    color: '#8e44ad',
-    icon: 'appstore',
-  },
   DEV_TOOL: {
     label: 'Developer tool',
     color: '#2c3e50',

--- a/frontend/client/modules/create/utils.ts
+++ b/frontend/client/modules/create/utils.ts
@@ -190,7 +190,7 @@ export function makeProposalPreviewFromDraft(draft: ProposalDraft): Proposal {
     contributionMatching: 0,
     percentFunded: 0,
     stage: 'preview',
-    category: draft.category || PROPOSAL_CATEGORY.DAPP,
+    category: draft.category || PROPOSAL_CATEGORY.CORE_DEV,
     isStaked: true,
     arbiter: {
       status: PROPOSAL_ARBITER_STATUS.ACCEPTED,


### PR DESCRIPTION
#### NOTE: Base branch should be switched to `develop` after `arbiter-management` is merged.

Closes https://github.com/grant-project/zcash-grant-system/issues/133

This PR removes the 'dapp' category from the backend API and as an option on the frontend.

