### PR TITLE
Remove 'DApp' category from Admin

### DIFF
--- a/admin/src/types.ts
+++ b/admin/src/types.ts
@@ -162,7 +162,6 @@ export interface EmailExample {
 }
 
 export enum PROPOSAL_CATEGORY {
-  DAPP = 'DAPP',
   DEV_TOOL = 'DEV_TOOL',
   CORE_DEV = 'CORE_DEV',
   COMMUNITY = 'COMMUNITY',

--- a/admin/src/util/ui.ts
+++ b/admin/src/util/ui.ts
@@ -10,11 +10,6 @@ interface EnumUIWithIcon extends EnumUI {
 }
 
 export const CATEGORY_UI: { [key in PROPOSAL_CATEGORY]: EnumUIWithIcon } = {
-  DAPP: {
-    label: 'DApp',
-    color: '#8e44ad',
-    icon: 'appstore',
-  },
   DEV_TOOL: {
     label: 'Developer tool',
     color: '#2c3e50',


### PR DESCRIPTION
### Note: Should be rebased against `develop` after `rfp-fields` is merged.

*Actually* closes https://github.com/grant-project/zcash-grant-system/issues/133 by removing `dapp` category from admin in addition to app.