### PR TITLE
Handle External Auth Events & Fix Double Loading

### DIFF
--- a/backend/grant/utils/auth.py
+++ b/backend/grant/utils/auth.py
@@ -18,7 +18,7 @@ def handle_auth_error(e):
 
 
 def get_authed_user():
-    return current_user if current_user.is_authenticated else None
+    return current_user if current_user.is_authenticated and not current_user.banned else None
 
 
 def throw_on_banned(user):

--- a/frontend/client/api/axios.ts
+++ b/frontend/client/api/axios.ts
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import { getStoreRef } from 'store/configure';
+import { checkUser } from 'modules/auth/actions';
 
 const instance = axios.create({
   baseURL: process.env.BACKEND_URL,
@@ -7,9 +9,24 @@ const instance = axios.create({
   withCredentials: true,
 });
 
+let lastAuthed = null as null | string;
+
 instance.interceptors.response.use(
-  // Do nothing to responses
-  res => res,
+  // - watch for changes to auth header and trigger checkUser action if it changes
+  // - this allows for external authorization events to be registered in this context
+  // - external auth events include login/logout in another tab, or
+  //   the user getting banned
+  res => {
+    const authed = res.headers['x-grantio-authed'];
+    if (lastAuthed !== null && lastAuthed !== authed) {
+      const store = getStoreRef();
+      if (store) {
+        store.dispatch<any>(checkUser());
+      }
+    }
+    lastAuthed = authed;
+    return res;
+  },
   // Try to parse error message if possible
   err => {
     if (err.response && err.response.data) {

--- a/frontend/client/modules/auth/reducers.ts
+++ b/frontend/client/modules/auth/reducers.ts
@@ -13,6 +13,8 @@ export interface AuthState {
   isCheckingUser: boolean;
   hasCheckedUser: boolean;
 
+  isLoggingOut: boolean;
+
   isCreatingUser: boolean;
   createUserError: string | null;
 
@@ -34,6 +36,8 @@ export const INITIAL_STATE: AuthState = {
 
   isCheckingUser: false,
   hasCheckedUser: false,
+
+  isLoggingOut: false,
 
   authSignature: null,
   authSignatureAddress: null,
@@ -81,6 +85,7 @@ export default function createReducer(
     case types.CHECK_USER_REJECTED:
       return {
         ...state,
+        user: null,
         isCheckingUser: false,
         hasCheckedUser: true,
       };
@@ -135,9 +140,22 @@ export default function createReducer(
         signAuthError: action.payload,
       };
 
+    case types.LOGOUT_PENDING:
+      return {
+        ...state,
+        isLoggingOut: true,
+        user: null,
+      };
     case types.LOGOUT_FULFILLED:
       return {
         ...state,
+        isLoggingOut: false,
+        user: null,
+      };
+    case types.LOGOUT_REJECTED:
+      return {
+        ...state,
+        isLoggingOut: false,
         user: null,
       };
 

--- a/frontend/client/store/configure.tsx
+++ b/frontend/client/store/configure.tsx
@@ -23,6 +23,11 @@ const bindMiddleware = (middleware: MiddleWare[]) => {
   return composeWithDevTools(applyMiddleware(...middleware));
 };
 
+let storeRef = null as null | Store<AppState>;
+export function getStoreRef() {
+  return storeRef;
+}
+
 export function configureStore(initialState: Partial<AppState> = combineInitialState) {
   const store: Store<AppState> = createStore(
     rootReducer,
@@ -44,6 +49,6 @@ export function configureStore(initialState: Partial<AppState> = combineInitialS
       );
     }
   }
-
+  storeRef = store;
   return { store };
 }

--- a/frontend/server/components/HTML.tsx
+++ b/frontend/server/components/HTML.tsx
@@ -5,7 +5,6 @@ import { ChunkExtractor } from '@loadable/server';
 export interface Props {
   children: any;
   css: string[];
-  scripts: string[];
   linkTags: Array<React.LinkHTMLAttributes<HTMLLinkElement>>;
   metaTags: Array<React.MetaHTMLAttributes<HTMLMetaElement>>;
   state: string;
@@ -15,7 +14,6 @@ export interface Props {
 
 const HTML: React.SFC<Props> = ({
   children,
-  scripts,
   css,
   state,
   i18n,
@@ -78,9 +76,9 @@ const HTML: React.SFC<Props> = ({
       </head>
       <body>
         <div id="app" dangerouslySetInnerHTML={{ __html: children }} />
-        {scripts.map(src => {
+        {/* {scripts.map(src => {
           return <script key={src} src={src} />;
-        })}
+        })} */}
       </body>
     </html>
   );

--- a/frontend/server/components/HTML.tsx
+++ b/frontend/server/components/HTML.tsx
@@ -76,9 +76,6 @@ const HTML: React.SFC<Props> = ({
       </head>
       <body>
         <div id="app" dangerouslySetInnerHTML={{ __html: children }} />
-        {/* {scripts.map(src => {
-          return <script key={src} src={src} />;
-        })} */}
       </body>
     </html>
   );

--- a/frontend/server/render.tsx
+++ b/frontend/server/render.tsx
@@ -53,9 +53,6 @@ const serverRenderer = async (req: Request, res: Response) => {
   const cssFiles = ['bundle.css', 'vendor.css']
     .map(f => res.locals.assetPath(f))
     .filter(Boolean);
-  const jsFiles = ['vendor.js', 'bundle.js']
-    .map(f => res.locals.assetPath(f))
-    .filter(Boolean);
   const mappedLinkTags = linkTags
     .map(l => ({ ...l, href: res.locals.assetPath(l.href) }))
     .filter(l => !!l.href);
@@ -66,7 +63,6 @@ const serverRenderer = async (req: Request, res: Response) => {
   const html = renderToString(
     <Html
       css={cssFiles}
-      scripts={jsFiles}
       linkTags={mappedLinkTags}
       metaTags={mappedMetaTags}
       state={state}


### PR DESCRIPTION
Closes #132. 

### What this does
- backend: sends a custom header on every api request with auth status
- frontend: axios watches this header and if it changes it calls the `checkUser` redux action
- this allows the redux store to update its auth status as soon as it learns about an authentication change via the header
- removes extra js scripts getting rendered to HTML, eliminating the double initialization behavior we were seeing

### Testing
1. open two tabs 
1. sign-in in one tab
1. in other tab, click any link that causes an api request (profile, requests, explore)
1. you should see "Sign in" replaced by avatar icon as redux drinks deeply your user data
1. now sign-out in one tab
1. in the other tab take any action that interacts with api, notice the avatar change to "Sign in", redux should now be in the unauthenticated state

* do a full reload of any page, watch the console logs, there should only be one set of `CHECK_USER_*` actions performed