### PR TITLE
Show bounty on proposal

### DIFF
--- a/frontend/client/components/Proposal/CampaignBlock/index.tsx
+++ b/frontend/client/components/Proposal/CampaignBlock/index.tsx
@@ -61,6 +61,14 @@ export class ProposalCampaignBlock extends React.Component<Props, State> {
       const isDisabled = isFundingOver || !!amountError || !amountFloat || isPreview;
       const remainingTargetNum = parseFloat(fromZat(target.sub(funded)));
 
+      // Get bounty from RFP. If it exceeds proposal target, show bounty as full amount
+      let bounty;
+      if (proposal.rfp && proposal.rfp.bounty) {
+        bounty = proposal.rfp.bounty.gt(proposal.target)
+          ? proposal.target
+          : proposal.rfp.bounty;
+      }
+
       content = (
         <React.Fragment>
           {isLive && (
@@ -95,6 +103,12 @@ export class ProposalCampaignBlock extends React.Component<Props, State> {
               <UnitDisplay value={funded} /> / <UnitDisplay value={target} symbol="ZEC" />
             </div>
           </div>
+
+          {bounty && (
+            <div className="ProposalCampaignBlock-bounty">
+              Awarded with <UnitDisplay value={bounty} symbol="ZEC" /> bounty
+            </div>
+          )}
 
           {proposal.contributionMatching > 0 && (
             <div className="ProposalCampaignBlock-matching">

--- a/frontend/client/components/Proposal/CampaignBlock/style.less
+++ b/frontend/client/components/Proposal/CampaignBlock/style.less
@@ -32,11 +32,11 @@
     }
   }
 
+  &-bounty,
   &-matching {
     margin: 0.5rem -1.5rem;
-    padding: 0.75rem 1.5rem;
+    padding: 0.75rem 1rem;
     text-align: center;
-    background: @info-color;
     color: #FFF;
     font-size: 1rem;
 
@@ -45,6 +45,19 @@
     }
   }
 
+  &-bounty {
+    background: @primary-color;
+  }
+
+  &-matching {
+    background: @info-color;
+  }
+
+  &-bounty + &-matching {
+    margin-top: 0;
+  }
+
+  
   &-popover {
     &-overlay {
       max-width: 400px;

--- a/frontend/client/utils/api.ts
+++ b/frontend/client/utils/api.ts
@@ -97,6 +97,9 @@ export function formatProposalFromGet(p: any): Proposal {
     proposal.milestones = proposal.milestones.map(msToFe);
     proposal.currentMilestone = msToFe(proposal.currentMilestone);
   }
+  if (proposal.rfp) {
+    proposal.rfp = formatRFPFromGet(proposal.rfp);
+  }
   return proposal;
 }
 
@@ -104,7 +107,9 @@ export function formatRFPFromGet(rfp: RFP): RFP {
   if (rfp.bounty) {
     rfp.bounty = toZat(rfp.bounty as any);
   }
-  rfp.acceptedProposals = rfp.acceptedProposals.map(formatProposalFromGet);
+  if (rfp.acceptedProposals) {
+    rfp.acceptedProposals = rfp.acceptedProposals.map(formatProposalFromGet);
+  }
   return rfp;
 }
 


### PR DESCRIPTION
Closes #205 

### What This Does

* Adds a banner to the campaign block that shows the bounty
* Adds the bounty to the `funded` hybrid property of proposals
* Allow proposals to instantly be marked as funded if they have sufficient bounty
* Fixes an issue where is_funded didn't take into account matching

### Steps to Test

* Make an RFP with a bounty
* Make a proposal with a target **below** that bounty
* Submit, approve, and publish it. Confirm it properly shows the banner, and switched to WIP stage.
* Make a proposal with a target **above** that bounty
* Submit, approve, and publish it. Confirm it properly shows the banner, and is still in funding stage.

## Screenshots

<img width="326" alt="screen shot 2019-02-15 at 10 22 07 pm" src="https://user-images.githubusercontent.com/649992/52894164-45967880-3173-11e9-9063-24643115be22.png">
