### PR TITLE
Standardize Profile Placeholders

### DIFF
--- a/frontend/client/components/Profile/index.tsx
+++ b/frontend/client/components/Profile/index.tsx
@@ -143,7 +143,10 @@ class Profile extends React.Component<Props, State> {
             <Tabs.TabPane tab={TabTitle('Created', proposals.length)} key="created">
               <div>
                 {noneCreated && (
-                  <Placeholder subtitle="Has not created any proposals yet" />
+                  <Placeholder
+                    title="No created proposals"
+                    subtitle="There have not been any created proposals."
+                  />
                 )}
                 {proposals.map(p => (
                   <ProfileProposal key={p.proposalId} proposal={p} />
@@ -153,7 +156,10 @@ class Profile extends React.Component<Props, State> {
             <Tabs.TabPane tab={TabTitle('Funded', contributions.length)} key="funded">
               <div>
                 {noneFunded && (
-                  <Placeholder subtitle="Has not funded any proposals yet" />
+                  <Placeholder
+                    title="No proposals funded"
+                    subtitle="There have not been any proposals funded."
+                  />
                 )}
                 {contributions.map(c => (
                   <ProfileContribution
@@ -168,7 +174,10 @@ class Profile extends React.Component<Props, State> {
             <Tabs.TabPane tab={TabTitle('Comments', comments.length)} key="comments">
               <div>
                 {noneCommented && (
-                  <Placeholder subtitle="Has not made any comments yet" />
+                  <Placeholder
+                    title="No comments"
+                    subtitle="There have not been any comments made"
+                  />
                 )}
                 {comments.map(c => (
                   <ProfileComment key={c.id} userName={user.displayName} comment={c} />
@@ -184,7 +193,7 @@ class Profile extends React.Component<Props, State> {
                 <div>
                   {noneInvites && (
                     <Placeholder
-                      title="No invites here!"
+                      title="No invitations"
                       subtitle="You’ll be notified when you’ve been invited to join a proposal"
                     />
                   )}


### PR DESCRIPTION
Closes https://github.com/grant-project/zcash-grant-system/issues/218

### What this does
- Updates all profile tab placeholders to have both title's and subtitles.

### Considerations
Profile tabs that are visible to just the user themselves remain directly addressing the user. Profile tabs that are public use passive language.