### PR TITLE
Show tags and brief on RFP detail

### DIFF
--- a/frontend/client/components/RFP/index.less
+++ b/frontend/client/components/RFP/index.less
@@ -23,11 +23,22 @@
     }
   }
 
+  &-brief {
+    font-size: 1rem;
+    margin-bottom: 1.75rem;
+    text-align: center;
+  }
+
+  &-tags {
+    text-align: center;
+    margin-bottom: 1.75rem;
+  }
+
   &-title {
     font-size: 2.4rem;
     text-align: center;
     font-weight: bold;
-    margin-bottom: 1.75rem;
+    margin-bottom: 1rem;
   }
 
   &-content {

--- a/frontend/client/components/RFP/index.tsx
+++ b/frontend/client/components/RFP/index.tsx
@@ -79,7 +79,6 @@ class RFPDetail extends React.Component<Props> {
 
         <h1 className="RFPDetail-title">{rfp.title}</h1>
         <div className="RFPDetail-tags">{tags}</div>
-
         <p className="RFPDetail-brief">{rfp.brief}</p>
 
         <Markdown className="RFPDetail-content" source={rfp.content} />

--- a/frontend/client/components/RFP/index.tsx
+++ b/frontend/client/components/RFP/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { Icon, Button, Affix } from 'antd';
+import { Icon, Button, Affix, Tag } from 'antd';
 import ExceptionPage from 'components/ExceptionPage';
 import { fetchRfp } from 'modules/rfps/actions';
 import { getRfp } from 'modules/rfps/selectors';
@@ -47,17 +47,41 @@ class RFPDetail extends React.Component<Props> {
       }
     }
 
+    const tags = [];
+
+    if (rfp.matching) {
+      tags.push(
+        <Tag key="matching" color="#1890ff">
+          x2 matching
+        </Tag>,
+      );
+    }
+
+    if (rfp.bounty) {
+      tags.push(
+        <Tag key="bounty" color="#CF8A00">
+          <UnitDisplay value={rfp.bounty} symbol="ZEC" /> bounty
+        </Tag>,
+      );
+    }
+
     return (
       <div className="RFPDetail">
         <div className="RFPDetail-top">
           <Link className="RFPDetail-top-back" to="/requests">
             <Icon type="arrow-left" /> Back to Requests
           </Link>
+
           <div className="RFPDetail-top-date">
             Opened {moment(rfp.dateOpened * 1000).format('LL')}
           </div>
         </div>
+
         <h1 className="RFPDetail-title">{rfp.title}</h1>
+        <div className="RFPDetail-tags">{tags}</div>
+
+        <p className="RFPDetail-brief">{rfp.brief}</p>
+
         <Markdown className="RFPDetail-content" source={rfp.content} />
         <div className="RFPDetail-rules">
           <ul>


### PR DESCRIPTION
Closes https://github.com/grant-project/zcash-grant-system/issues/225

### What this does
Adds content only displayed on the listview to the detail view for RFPs.


### Why?
So users don't have to go back and forth between views to have a total picture of the RFP.


### Before
<img width="914" alt="screen shot 2019-02-18 at 12 10 13 pm" src="https://user-images.githubusercontent.com/7861465/52969485-29aef480-3376-11e9-9b4a-1af90c582272.png">

### After
<img width="969" alt="screen shot 2019-02-18 at 12 07 20 pm" src="https://user-images.githubusercontent.com/7861465/52969447-0a17cc00-3376-11e9-8673-85a955a45a7d.png">
