### PR TITLE
Remove Sprout contributions

### DIFF
--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -700,7 +700,12 @@ class ProposalContributionSchema(ma.Schema):
         return dt_to_unix(obj.date_created)
 
     def get_addresses(self, obj):
-        return blockchain_get('/contribution/addresses', {'contributionId': obj.id})
+        # Omit 'memo' and 'sprout' for now
+        # TODO: Add back in 'sapling' when ready
+        addresses = blockchain_get('/contribution/addresses', {'contributionId': obj.id})
+        return {
+            'transparent': addresses['transparent'],
+        }
 
 
 proposal_contribution_schema = ProposalContributionSchema()

--- a/frontend/client/components/ContributionModal/PaymentInfo.tsx
+++ b/frontend/client/components/ContributionModal/PaymentInfo.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import classnames from 'classnames';
-import { Button, Form, Icon, Radio } from 'antd';
+import { Button, Form, Icon, Radio, Alert } from 'antd';
 import { RadioChangeEvent } from 'antd/lib/radio';
 import QRCode from 'qrcode.react';
 import { formatZcashCLI, formatZcashURI } from 'utils/formatters';
@@ -22,7 +22,7 @@ interface State {
 
 export default class PaymentInfo extends React.Component<Props, State> {
   state: State = {
-    sendType: 'sprout',
+    sendType: 'transparent',
   };
 
   render() {
@@ -36,12 +36,71 @@ export default class PaymentInfo extends React.Component<Props, State> {
 
     if (contribution) {
       if (sendType !== 'transparent') {
-        memo = contribution.addresses.memo;
+        memo = 'Fix me';
+        // memo = contribution.addresses.memo;
       }
-      address = contribution.addresses[sendType];
+      // address = contribution.addresses[sendType];
+      address = contribution.addresses.transparent;
       amount = contribution.amount;
       cli = formatZcashCLI(address, amount, memo);
       uri = formatZcashURI(address, amount, memo);
+    }
+
+    let content;
+    if (sendType === 'sprout') {
+      content = (
+        <Alert
+          type="warning"
+          message="Not yet supported"
+          description={`
+            Unfortunately, sapling addresses aren't yet supported, and sprout addresses
+            have been deprecated. We hope to add support in the near future!
+          `}
+          showIcon
+        />
+      );
+    } else {
+      content = (
+        <>
+          <div className="PaymentInfo-uri">
+            <div className={classnames('PaymentInfo-uri-qr', !uri && 'is-loading')}>
+              <span style={{ opacity: uri ? 1 : 0 }}>
+                <QRCode value={uri || ''} />
+              </span>
+              {!uri && <Loader />}
+            </div>
+            <div className="PaymentInfo-uri-info">
+              <CopyInput
+                className="PaymentInfo-uri-info-input"
+                label="Payment URI"
+                value={uri}
+                isTextarea
+              />
+              <Button type="ghost" size="large" href={uri} block>
+                Open in Wallet <Icon type="link" />
+              </Button>
+            </div>
+          </div>
+
+          <div className="PaymentInfo-fields">
+            <div className="PaymentInfo-fields-row">
+              <CopyInput
+                className="PaymentInfo-fields-row-address"
+                label="Address"
+                value={address}
+              />
+              {memo && <CopyInput label="Memo" value={memo} />}
+            </div>
+            <div className="PaymentInfo-fields-row">
+              <CopyInput
+                label="Zcash CLI command"
+                help="Make sure you replace YOUR_ADDRESS with your actual address"
+                value={cli}
+              />
+            </div>
+          </div>
+        </>
+      );
     }
 
     return (
@@ -53,53 +112,15 @@ export default class PaymentInfo extends React.Component<Props, State> {
             you, and we'll let you know when your contribution has been confirmed.
           `}
         </div>
-
         <Radio.Group
           className="PaymentInfo-types"
           onChange={this.handleChangeSendType}
           value={sendType}
         >
-          <Radio.Button value="sprout">Z Address (Private)</Radio.Button>
           <Radio.Button value="transparent">T Address (Public)</Radio.Button>
+          <Radio.Button value="sprout">Z Address (Private)</Radio.Button>
         </Radio.Group>
-
-        <div className="PaymentInfo-uri">
-          <div className={classnames('PaymentInfo-uri-qr', !uri && 'is-loading')}>
-            <span style={{ opacity: uri ? 1 : 0 }}>
-              <QRCode value={uri || ''} />
-            </span>
-            {!uri && <Loader />}
-          </div>
-          <div className="PaymentInfo-uri-info">
-            <CopyInput
-              className="PaymentInfo-uri-info-input"
-              label="Payment URI"
-              value={uri}
-              isTextarea
-            />
-            <Button type="ghost" size="large" href={uri} block>
-              Open in Wallet <Icon type="link" />
-            </Button>
-          </div>
-        </div>
-
-        <div className="PaymentInfo-fields">
-          <div className="PaymentInfo-fields-row">
-            <CopyInput
-              className="PaymentInfo-fields-row-address"
-              label="Address"
-              value={address}
-            />
-            {memo && <CopyInput label="Memo" value={memo} />}
-          </div>
-          <div className="PaymentInfo-fields-row">
-            <CopyInput
-              label="Zcash CLI command"
-              help="Make sure you replace YOUR_ADDRESS with your actual address"
-              value={cli}
-            />
-          </div>
-        </div>
+        {content}
       </Form>
     );
   }

--- a/frontend/types/contribution.ts
+++ b/frontend/types/contribution.ts
@@ -11,9 +11,10 @@ export interface Contribution {
 
 export interface ContributionWithAddresses extends Contribution {
   addresses: {
-    sprout: string;
     transparent: string;
-    memo: string;
+    // TODO: Add sapling and memo in when ready
+    // sprout: string;
+    // memo: string;
   };
 }
 


### PR DESCRIPTION
Closes #246.

### What This Does

Removes sprout contributions in the least destructive, most minimal way possible. Simply omits the response of sprout address & memo from the backend, adds a warning to the frontend, and makes transparent the default. If we need to get more hands-on with this, let me know. Should make the transition to sapling much easier to implement than if we ripped the whole thing out.

### Steps to Test

* Contribute to a proposal, confirm you can't sprout it up

## Screenshots

### T as default

<img width="534" alt="screen shot 2019-02-22 at 2 16 13 pm" src="https://user-images.githubusercontent.com/649992/53265746-fee1da80-36ac-11e9-9ab6-1ccb5f5c19e2.png">

### Z warning

<img width="546" alt="screen shot 2019-02-22 at 2 17 19 pm" src="https://user-images.githubusercontent.com/649992/53265765-06a17f00-36ad-11e9-854e-40c55fb6c322.png">
