### PR TITLE
Handle only showing canel and refund popover correctly

### DIFF
--- a/admin/src/components/ProposalDetail/index.tsx
+++ b/admin/src/components/ProposalDetail/index.tsx
@@ -346,33 +346,30 @@ class ProposalDetailNaked extends React.Component<Props, State> {
       );
     };
 
-    const renderFailed = () => {
-      return (
-        p.isFailed && (
-          <Alert
-            showIcon
-            type="error"
-            message={
-              p.stage === PROPOSAL_STAGE.FAILED ? 'Proposal failed' : 'Proposal canceled'
-            }
-            description={
-              p.stage === PROPOSAL_STAGE.FAILED ? (
-                <>
-                  This proposal failed to reach its funding goal of <b>{p.target} ZEC</b>{' '}
-                  by <b>{formatDateSeconds(p.datePublished + p.deadlineDuration)}</b>. All
-                  contributors will need to be refunded.
-                </>
-              ) : (
-                <>
-                  This proposal was canceled by an admin, and will be refunding
-                  contributors <b>{refundablePct}%</b> of their contributions.
-                </>
-              )
-            }
-          />
-        )
+    const renderFailed = () =>
+      p.isFailed && (
+        <Alert
+          showIcon
+          type="error"
+          message={
+            p.stage === PROPOSAL_STAGE.FAILED ? 'Proposal failed' : 'Proposal canceled'
+          }
+          description={
+            p.stage === PROPOSAL_STAGE.FAILED ? (
+              <>
+                This proposal failed to reach its funding goal of <b>{p.target} ZEC</b> by{' '}
+                <b>{formatDateSeconds(p.datePublished + p.deadlineDuration)}</b>. All
+                contributors will need to be refunded.
+              </>
+            ) : (
+              <>
+                This proposal was canceled by an admin, and will be refunding contributors{' '}
+                <b>{refundablePct}%</b> of their contributions.
+              </>
+            )
+          }
+        />
       );
-    };
 
     const renderDeetItem = (name: string, val: any) => (
       <div className="ProposalDetail-deet">

--- a/admin/src/components/ProposalDetail/index.tsx
+++ b/admin/src/components/ProposalDetail/index.tsx
@@ -36,6 +36,7 @@ type Props = RouteComponentProps<any>;
 
 const STATE = {
   paidTxId: '',
+  showCancelAndRefundPopover: false,
 };
 
 type State = typeof STATE;
@@ -77,10 +78,7 @@ class ProposalDetailNaked extends React.Component<Props, State> {
     );
 
     const renderCancelControl = () => {
-      const disabled =
-        p.status !== PROPOSAL_STATUS.LIVE ||
-        p.stage === PROPOSAL_STAGE.FAILED ||
-        p.stage === PROPOSAL_STAGE.CANCELED;
+      const disabled = this.getCancelAndRefundDisabled();
 
       return (
         <Popconfirm
@@ -94,16 +92,18 @@ class ProposalDetailNaked extends React.Component<Props, State> {
           placement="left"
           cancelText="cancel"
           okText="confirm"
-          visible={!disabled}
+          visible={this.state.showCancelAndRefundPopover}
           okButtonProps={{
             loading: store.proposalDetailCanceling,
           }}
-          onConfirm={this.handleCancel}
+          onCancel={this.handleCancelCancel}
+          onConfirm={this.handleConfirmCancel}
         >
           <Button
             icon="close-circle"
             className="ProposalDetail-controls-control"
             loading={store.proposalDetailCanceling}
+            onClick={this.handleCancelAndRefundClick}
             disabled={disabled}
             block
           >
@@ -346,30 +346,33 @@ class ProposalDetailNaked extends React.Component<Props, State> {
       );
     };
 
-    const renderFailed = () =>
-      p.isFailed && (
-        <Alert
-          showIcon
-          type="error"
-          message={
-            p.stage === PROPOSAL_STAGE.FAILED ? 'Proposal failed' : 'Proposal canceled'
-          }
-          description={
-            p.stage === PROPOSAL_STAGE.FAILED ? (
-              <>
-                This proposal failed to reach its funding goal of <b>{p.target} ZEC</b> by{' '}
-                <b>{formatDateSeconds(p.datePublished + p.deadlineDuration)}</b>. All
-                contributors will need to be refunded.
-              </>
-            ) : (
-              <>
-                This proposal was canceled by an admin, and will be refunding contributors{' '}
-                <b>{refundablePct}%</b> of their contributions.
-              </>
-            )
-          }
-        />
+    const renderFailed = () => {
+      return (
+        p.isFailed && (
+          <Alert
+            showIcon
+            type="error"
+            message={
+              p.stage === PROPOSAL_STAGE.FAILED ? 'Proposal failed' : 'Proposal canceled'
+            }
+            description={
+              p.stage === PROPOSAL_STAGE.FAILED ? (
+                <>
+                  This proposal failed to reach its funding goal of <b>{p.target} ZEC</b>{' '}
+                  by <b>{formatDateSeconds(p.datePublished + p.deadlineDuration)}</b>. All
+                  contributors will need to be refunded.
+                </>
+              ) : (
+                <>
+                  This proposal was canceled by an admin, and will be refunding
+                  contributors <b>{refundablePct}%</b> of their contributions.
+                </>
+              )
+            }
+          />
+        )
       );
+    };
 
     const renderDeetItem = (name: string, val: any) => (
       <div className="ProposalDetail-deet">
@@ -477,6 +480,28 @@ class ProposalDetailNaked extends React.Component<Props, State> {
     );
   }
 
+  private getCancelAndRefundDisabled = () => {
+    const { proposalDetail: p } = store;
+    if (!p) {
+      return true;
+    }
+    return (
+      p.status !== PROPOSAL_STATUS.LIVE ||
+      p.stage === PROPOSAL_STAGE.FAILED ||
+      p.stage === PROPOSAL_STAGE.CANCELED ||
+      p.isFailed
+    );
+  };
+
+  private handleCancelAndRefundClick = () => {
+    const disabled = this.getCancelAndRefundDisabled();
+    if (!disabled) {
+      if (!this.state.showCancelAndRefundPopover) {
+        this.setState({ showCancelAndRefundPopover: true });
+      }
+    }
+  };
+
   private getIdFromQuery = () => {
     return Number(this.props.match.params.id);
   };
@@ -490,9 +515,14 @@ class ProposalDetailNaked extends React.Component<Props, State> {
     store.deleteProposal(store.proposalDetail.proposalId);
   };
 
-  private handleCancel = () => {
+  private handleCancelCancel = () => {
+    this.setState({ showCancelAndRefundPopover: false });
+  };
+
+  private handleConfirmCancel = () => {
     if (!store.proposalDetail) return;
     store.cancelProposal(store.proposalDetail.proposalId);
+    this.setState({ showCancelAndRefundPopover: false });
   };
 
   private handleApprove = () => {


### PR DESCRIPTION
No related issue. Solves bug described in https://github.com/grant-project/zcash-grant-system/pull/277#issuecomment-468991409

### What this does

Adds better state handling to handle when the "Cancel & Refund" popconfirm is visible, so that it isn't shown simply when Handle & Confirm isn't disabled. 

![2019-03-02 23 42 55](https://user-images.githubusercontent.com/7861465/53691507-140dd780-3d45-11e9-806c-22f3f9f00299.gif)

