### PR TITLE
RFP Bounty Fixes

### DIFF
--- a/backend/grant/admin/views.py
+++ b/backend/grant/admin/views.py
@@ -496,9 +496,10 @@ def get_rfp(rfp_id):
     "brief": fields.Str(required=True),
     "content": fields.Str(required=True),
     "category": fields.Str(required=True, validate=validate.OneOf(choices=Category.list())),
-    "bounty": fields.Str(required=True),
-    "matching": fields.Bool(required=True, default=False, missing=False),
-    "dateCloses": fields.Int(required=True)
+    "bounty": fields.Str(required=False, missing=""),
+    "matching": fields.Bool(required=False, default=False, missing=False),
+    "dateCloses": fields.Int(required=False, missing=None),
+    "status": fields.Str(required=True, validate=validate.OneOf(choices=RFPStatus.list())),
 })
 @admin.admin_auth_required
 def update_rfp(rfp_id, title, brief, content, category, bounty, matching, date_closes, status):
@@ -511,8 +512,8 @@ def update_rfp(rfp_id, title, brief, content, category, bounty, matching, date_c
     rfp.brief = brief
     rfp.content = content
     rfp.category = category
-    rfp.bounty = bounty
     rfp.matching = matching
+    rfp.bounty = bounty if bounty and bounty != "" else None
     rfp.date_closes = datetime.fromtimestamp(date_closes) if date_closes else None
 
     # Update timestamps if status changed

--- a/backend/grant/app.py
+++ b/backend/grant/app.py
@@ -38,6 +38,7 @@ def create_app(config_objects=["grant.settings"]):
     @app.errorhandler(422)
     @app.errorhandler(400)
     def handle_error(err):
+        print(err)
         headers = err.data.get("headers", None)
         messages = err.data.get("messages", "Invalid request.")
         error_message = "Something went wrong with your request. That's all we know"

--- a/backend/grant/app.py
+++ b/backend/grant/app.py
@@ -38,7 +38,6 @@ def create_app(config_objects=["grant.settings"]):
     @app.errorhandler(422)
     @app.errorhandler(400)
     def handle_error(err):
-        print(err)
         headers = err.data.get("headers", None)
         messages = err.data.get("messages", "Invalid request.")
         error_message = "Something went wrong with your request. That's all we know"

--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -506,7 +506,7 @@ class Proposal(db.Model):
         # apply matching multiplier
         funded = Decimal(self.contributed) * Decimal(1 + self.contribution_matching)
         # apply bounty, if available
-        if self.rfp:
+        if self.rfp and self.rfp.bounty and self.rfp.bounty != "":
             funded = funded + Decimal(self.rfp.bounty)
         # if funded > target, just set as target
         if funded > target:

--- a/frontend/client/components/Home/Requests.tsx
+++ b/frontend/client/components/Home/Requests.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import BN from 'bn.js';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { withNamespaces, WithNamespaces } from 'react-i18next';
@@ -28,7 +29,16 @@ class HomeRequests extends React.Component<Props> {
 
   render() {
     const { t, rfps, isFetchingRfps } = this.props;
-    const activeRfps = (rfps || []).filter(rfp => rfp.status === RFP_STATUS.LIVE).slice(0, 2);
+
+    // 2 live RFPs, sorted by highest bounty first
+    const activeRfps = (rfps || [])
+      .filter(rfp => rfp.status === RFP_STATUS.LIVE)
+      .sort((a, b) => {
+        const aBounty = a.bounty || new BN(0);
+        const bBounty = b.bounty || new BN(0);
+        return bBounty.sub(aBounty).toNumber();
+      })
+      .slice(0, 2);
 
     let content;
     if (activeRfps.length) {


### PR DESCRIPTION
Closes #287, addresses some issues found along the way.

### What This Does

* Sorts homepage by highest bounty first
* Fixes the edit RFP page endpoint to add `status` argument, handle missing `date_closes` argument
* Fixes linked RFPs with proposals that don't have bounties trying to cast `None` to `Decimal` (to add to contributions.)

### Steps to Test

* Confirm you can create and edit an RFP
* Confirm that homepage shows live RFPs sorted by bounty
* Confirm that a proposal can link to an RFP with no bounty