### PR TITLE
Reduce payload size for bootstrap & other fixes

### DIFF
--- a/backend/grant/blockchain/bootstrap.py
+++ b/backend/grant/blockchain/bootstrap.py
@@ -1,9 +1,6 @@
 from datetime import datetime, timedelta
 
-from grant.proposal.models import (
-    ProposalContribution,
-    proposal_contributions_schema,
-)
+from grant.proposal.models import ProposalContribution
 from grant.utils.requests import blockchain_post
 from grant.utils.enums import ContributionStatus
 
@@ -17,8 +14,9 @@ def make_bootstrap_data():
         .filter_by(status=ContributionStatus.CONFIRMED) \
         .order_by(ProposalContribution.date_created.desc()) \
         .first()
+    serialized_pending_contributions = list(map(lambda c: {"id": c.id}, pending_contributions))
     return {
-        "pendingContributions": proposal_contributions_schema.dump(pending_contributions),
+        "pendingContributions": serialized_pending_contributions,
         "latestTxId": latest_contribution.tx_id if latest_contribution else None,
     }
 

--- a/backend/grant/blockchain/views.py
+++ b/backend/grant/blockchain/views.py
@@ -11,4 +11,4 @@ blueprint = Blueprint("blockchain", __name__, url_prefix="/api/v1/blockchain")
 def get_bootstrap_info():
     print('Bootstrap data requested from blockchain watcher microservice...')
     send_bootstrap_data()
-    return True
+    return {"message": "ok"}, 200

--- a/blockchain/src/node.ts
+++ b/blockchain/src/node.ts
@@ -194,7 +194,8 @@ export async function getBootstrapBlockHeight(txid: string | undefined) {
     try {
       const tx = await node.gettransaction(txid);
       const block = await node.getblock(tx.blockhash);
-      return block.height.toString();
+      const height = block.height - parseInt(env.MINIMUM_BLOCK_CONFIRMATIONS, 10);
+      return height.toString();
     } catch(err) {
       console.warn(`Attempted to get block height for tx ${txid} but failed with the following error:\n`, err);
       console.warn('Falling back to hard-coded starter blocks');


### PR DESCRIPTION
Closes #271 with some other small changes

### What This Does

* Sends only contribution IDs instead of the full serialized object for a smaller payload
* Fixes bootstrap endpoint response to be valid Flask response (was boolean)
* Blockchain watcher now starts from last confirmed tx block - min confirmations, to catch any potential straggler contributions

### Steps to Test

Start the blockchain watcher _after_ the flask server has started when you have pending contributions and a confirmed contribution with a valid txid, confirm it boots correctly.