### PR TITLE
Fix homepage horizontal scroll

### DIFF
--- a/frontend/client/components/Home/Intro.less
+++ b/frontend/client/components/Home/Intro.less
@@ -8,6 +8,7 @@
   max-width: 1440px;
   padding: 0 4rem;
   margin: 0 auto 6rem;
+  overflow: hidden;
 
   @media @thin-query {
     padding: 0 2rem;


### PR DESCRIPTION
Closes #269. Overflow hidden on home intro. Just size your browser to 1000px on homepage, make sure it can't scroll horizontally.