### PR TITLE
Profile Comments Bugs

### DIFF
--- a/frontend/client/components/Profile/ProfileComment.less
+++ b/frontend/client/components/Profile/ProfileComment.less
@@ -1,5 +1,4 @@
 .ProfileComment {
-  padding-bottom: 1.2rem;
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);
   margin-bottom: 1rem;
 

--- a/frontend/client/components/Profile/ProfileComment.tsx
+++ b/frontend/client/components/Profile/ProfileComment.tsx
@@ -28,7 +28,7 @@ export default class Profile extends React.Component<OwnProps> {
           >
             {proposal.title}
           </Link>{' '}
-          {moment(dateCreated).from(Date.now())}
+          {moment(dateCreated * 1000).from(Date.now())}
         </div>
         <Markdown source={content} type={MARKDOWN_TYPE.REDUCED} />
       </div>

--- a/frontend/client/components/Profile/ProfileComment.tsx
+++ b/frontend/client/components/Profile/ProfileComment.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 import { UserComment } from 'types';
+import Markdown from 'components/Markdown';
+import { MARKDOWN_TYPE } from 'utils/markdown';
 import './ProfileComment.less';
 
 interface OwnProps {
@@ -28,7 +30,7 @@ export default class Profile extends React.Component<OwnProps> {
           </Link>{' '}
           {moment(dateCreated).from(Date.now())}
         </div>
-        <div className="ProfileComment-body">{content}</div>
+        <Markdown source={content} type={MARKDOWN_TYPE.REDUCED} />
       </div>
     );
   }


### PR DESCRIPTION
Closes #278.

- Uses `Markdown` renderer for user profile comments. 
- Converts profile comments dateCreated to milliseconds.

![screen shot 2019-03-05 at 11 40 36 am](https://user-images.githubusercontent.com/11430954/53825356-bee7e680-3f3b-11e9-9f38-60ef6d973ee4.png)


