### PR TITLE
Revert contribution ids to be incremental.

### DIFF
--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -94,7 +94,6 @@ class ProposalContribution(db.Model):
             user_id: int = None,
             staking: bool = False,
     ):
-        self.id = gen_random_id(ProposalUpdate)
         self.proposal_id = proposal_id
         self.amount = amount
         self.user_id = user_id


### PR DESCRIPTION
Closes #301.

Returns contributions to auto-increment ids, for bip32 simplicity. Also of note, I had been passing in the wrong model the whole time, so that's embarrassing (expand the diff if you're confused.)