### PR TITLE
Homepage image loading improvement

### DIFF
--- a/frontend/client/components/Home/Intro.less
+++ b/frontend/client/components/Home/Intro.less
@@ -96,11 +96,15 @@
   }
 
   &-illustration {
+    position: relative;
+    width: 100%;
     max-width: 640px;
+    background-size: contain;
 
-    img {
-      width: 100%;
-      height: auto;
+    &:after {
+      content: '';
+      display: block;
+      padding-top: 86.3%; // Aspect ratio of img
     }
 
     @media @thin-query {

--- a/frontend/client/components/Home/Intro.tsx
+++ b/frontend/client/components/Home/Intro.tsx
@@ -32,9 +32,10 @@ const HomeIntro: React.SFC<Props> = ({ t, authUser }) => (
         </a>
       </div>
     </div>
-    <div className="HomeIntro-illustration">
-      <img src={HomeIllustration} />
-    </div>
+    <div
+      className="HomeIntro-illustration"
+      style={{ backgroundImage: `url(${HomeIllustration})` }}
+    />
   </div>
 );
 


### PR DESCRIPTION
Noticed this while testing on heroku, the way the image loads right now, it doesn't hold its shape until the png loads. This changes it to be a background image that maintains shape even before the image has loaded.

## Before

![homepage-old](https://user-images.githubusercontent.com/649992/53921786-c09ad280-403f-11e9-82ae-c61d86b58a25.gif)


## After

![homepage-new](https://user-images.githubusercontent.com/649992/53921789-c2fd2c80-403f-11e9-92d2-5d08dc4cdb3f.gif)

