### PR TITLE
Session Cookie Domain Backend Setting

### DIFF
--- a/admin/src/components/MFAuth/index.tsx
+++ b/admin/src/components/MFAuth/index.tsx
@@ -173,7 +173,7 @@ class MFAuth extends React.Component<Props, State> {
           <ol>
             <li>Save two-factor recovery codes</li>
             <li>
-              Setup up TOTP authentication device, typically a smartphone with Google
+              Setup TOTP authentication device, typically a smartphone with Google
               Authenticator, Authy, 1Password or other compatible authenticator app.
             </li>
           </ol>

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,6 +7,9 @@ REDISTOGO_URL="redis://localhost:6379"
 SECRET_KEY="not-so-secret"
 SENDGRID_API_KEY="optional, but emails won't send without it"
 
+# set this so third-party cookie blocking doesn't kill backend sessions (production)
+# SESSION_COOKIE_DOMAIN="zfnd.org"
+
 # SENTRY_DSN="https://PUBLICKEY@sentry.io/PROJECTID"
 # SENTRY_RELEASE="optional, provides sentry logging with release info"
 

--- a/backend/grant/settings.py
+++ b/backend/grant/settings.py
@@ -16,7 +16,7 @@ ENV = env.str("FLASK_ENV", default="production")
 DEBUG = ENV == "development"
 SITE_URL = env.str('SITE_URL', default='https://zfnd.org')
 SQLALCHEMY_DATABASE_URI = env.str("DATABASE_URL")
-SQLALCHEMY_ECHO = False # True will print queries to log
+SQLALCHEMY_ECHO = False  # True will print queries to log
 QUEUES = ["default"]
 SECRET_KEY = env.str("SECRET_KEY")
 BCRYPT_LOG_ROUNDS = env.int("BCRYPT_LOG_ROUNDS", default=13)
@@ -24,6 +24,9 @@ DEBUG_TB_ENABLED = DEBUG
 DEBUG_TB_INTERCEPT_REDIRECTS = False
 CACHE_TYPE = "simple"  # Can be "memcached", "redis", etc.
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+# so backend session cookies are first-party
+SESSION_COOKIE_DOMAIN = env.str('SESSION_COOKIE_DOMAIN', default=None)
 
 SENDGRID_API_KEY = env.str("SENDGRID_API_KEY", default="")
 SENDGRID_DEFAULT_FROM = "noreply@zfnd.org"


### PR DESCRIPTION
Closes #306.

### What
- adds `SESSION_COOKIE_DOMAIN` setting to backend (for production)
- fixes typo

### Testing
- wait for the next heroku deploy (making sure to set SESSION_COOKIE_DOMAIN on backend)
- OR if you want to or already have dev domains set up
    - edit [hosts](https://www.imore.com/how-edit-your-macs-hosts-file-and-why-you-would-want) or use [dnsmasq](https://medium.com/@kharysharpe/automatic-local-domains-setting-up-dnsmasq-for-macos-high-sierra-using-homebrew-caf767157e43)
    - use `zfnd.test` as the root (or whatever)
    - set backend `.env` `SESSION_COOKIE_DOMAIN="zfnd.test"` replacing 'zfnd.test' with whatever you are using
- set your browser to block third-party cookies 
- attempt to sign-in. It should successfully authenticate.