### PR TITLE
Add noscript messages

### DIFF
--- a/frontend/client/components/AuthRoute.tsx
+++ b/frontend/client/components/AuthRoute.tsx
@@ -53,7 +53,15 @@ class AuthRoute extends React.Component<Props> {
       if (onlyLoggedOut) {
         newLocation = authForwardLocation || { ...location, pathname: '/profile' };
       }
-      return <Redirect to={{ ...newLocation }} />;
+      return (
+        <>
+          <noscript className="noScript is-block">
+            This page requires you to login before you can access it, but you have
+            Javascript disabled. Please enable Javascript and login to continue.
+          </noscript>
+          <Redirect to={{ ...newLocation }} />
+        </>
+      );
     }
   }
   private setAuthForward = () => {

--- a/frontend/client/components/Template/index.tsx
+++ b/frontend/client/components/Template/index.tsx
@@ -29,6 +29,12 @@ export default class Template extends React.PureComponent<Props> {
     );
     return (
       <BasicHead title={title}>
+        {!isHeaderTransparent && (
+          <noscript className="noScript is-banner">
+            It looks like you have Javascript disabled. You may experience issues with
+            interactive parts of the site.
+          </noscript>
+        )}
         <div className={className}>
           <Header isTransparent={isHeaderTransparent} />
           <Layout.Content className="Template-content">

--- a/frontend/client/pages/auth.tsx
+++ b/frontend/client/pages/auth.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import AuthFlow from 'components/AuthFlow';
 
-const SignInPage = () => <AuthFlow />;
+const SignInPage = () => (
+  <>
+    <noscript className="noScript is-block">
+      Sign in and account creation require Javascript. Please enable it to continue.
+    </noscript>
+    <AuthFlow />
+  </>
+);
 
 export default SignInPage;

--- a/frontend/client/pages/create.tsx
+++ b/frontend/client/pages/create.tsx
@@ -10,7 +10,14 @@ class CreatePage extends React.Component<Props> {
     const { location } = this.props;
     const parsed = parse(location.search);
     const rfpId = parsed.rfp ? parseInt(parsed.rfp, 10) : undefined;
-    return <DraftList createIfNone createWithRfpId={rfpId} />;
+    return (
+      <>
+        <noscript className="noScript is-block">
+          Proposal creation requires Javascript. You’ll need to enable
+        </noscript>
+        <DraftList createIfNone createWithRfpId={rfpId} />
+      </>
+    );
   }
 }
 

--- a/frontend/client/pages/create.tsx
+++ b/frontend/client/pages/create.tsx
@@ -13,7 +13,7 @@ class CreatePage extends React.Component<Props> {
     return (
       <>
         <noscript className="noScript is-block">
-          Proposal creation requires Javascript. You’ll need to enable
+          Proposal creation requires Javascript. You’ll need to enable it to continue.
         </noscript>
         <DraftList createIfNone createWithRfpId={rfpId} />
       </>

--- a/frontend/client/styles/noscript.less
+++ b/frontend/client/styles/noscript.less
@@ -1,0 +1,39 @@
+@import 'variables.less';
+
+.noScript {
+  display: block;
+
+  &.is-banner {
+    padding: 0.25rem 1rem;
+    text-align: center;
+    background: @warning-color;
+    color: #FFF;
+  }
+
+  &.is-block {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    max-width: 420px;
+    margin: 2rem auto;
+    padding: 1.5rem;
+    border: 1px solid @warning-color;
+    background: rgba(@warning-color, 0.05);
+    border-radius: 2px;
+
+    &:before {
+      content: '!';
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-shrink: 0;
+      font-size: 1.8rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      margin-right: 1rem;
+      border: 2px solid @warning-color;
+      color: @warning-color;
+      border-radius: 100%;
+    }
+  }
+}

--- a/frontend/client/styles/style.less
+++ b/frontend/client/styles/style.less
@@ -9,3 +9,4 @@
 @import 'react-mde-overrides.less';
 @import 'antd-overrides.less';
 @import 'html.less';
+@import 'noscript.less';


### PR DESCRIPTION
Closes #308.

### What This Does

* Adds a persistent `<noscript>` banner to the top of every page (Except the homepage)
* Adds `<noscript>` warnings on pages that are particularly busted (create, auth)

### Steps to Test

* Run the site with production build, or flip the isDev booleans in loaders.tsx:64-65 to change style-loader for css extract plugin loader
* Disable javascript on the site (Click the button to the left of domain, site settings, block Javascript)
* Confirm that you see the warning on all non-homepage pages
* Confirm you see the extra warnings on pages that previously just showed white screens

## Screenshots

<img width="1552" alt="Screen Shot 2019-03-12 at 5 56 56 PM" src="https://user-images.githubusercontent.com/649992/54241791-8a09ff80-44f8-11e9-8b30-68f567d90c35.png">
<img width="1552" alt="Screen Shot 2019-03-12 at 5 57 03 PM" src="https://user-images.githubusercontent.com/649992/54241794-8bd3c300-44f8-11e9-92d2-7c5101cd962f.png">
<img width="1552" alt="Screen Shot 2019-03-12 at 5 57 11 PM" src="https://user-images.githubusercontent.com/649992/54241795-8d9d8680-44f8-11e9-9358-f9856adf4977.png">
