### PR TITLE
Rate limits

### DIFF
--- a/backend/grant/app.py
+++ b/backend/grant/app.py
@@ -2,14 +2,14 @@
 """The app module, containing the app factory function."""
 import sentry_sdk
 from animal_case import animalify
-from flask import Flask, Response, jsonify
+from flask import Flask, Response, jsonify, request
 from flask_cors import CORS
 from flask_security import SQLAlchemyUserDatastore
 from flask_sslify import SSLify
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 from grant import commands, proposal, user, comment, milestone, admin, email, blockchain, task, rfp
-from grant.extensions import bcrypt, migrate, db, ma, security
+from grant.extensions import bcrypt, migrate, db, ma, security, limiter
 from grant.settings import SENTRY_RELEASE, ENV
 from grant.utils.auth import AuthException, handle_auth_error, get_authed_user
 from grant.utils.exceptions import ValidationException
@@ -48,7 +48,12 @@ def create_app(config_objects=["grant.settings"]):
             return jsonify({"message": error_message}), err.code, headers
         else:
             return jsonify({"message": error_message}), err.code
-    
+
+    @app.errorhandler(429)
+    def handle_limit_error(err):
+        print(f'Rate limited request to {request.method} {request.path} from ip {request.remote_addr}')
+        return jsonify({"message": "You’ve done that too many times, please wait and try again later"}), 429
+
     @app.errorhandler(Exception)
     def handle_exception(err):
         return jsonify({"message": "Something went wrong"}), 500
@@ -86,6 +91,7 @@ def register_extensions(app):
     db.init_app(app)
     migrate.init_app(app, db)
     ma.init_app(app)
+    limiter.init_app(app)
     user_datastore = SQLAlchemyUserDatastore(db, user.models.User, user.models.Role)
     security.init_app(app, datastore=user_datastore, register_blueprint=False)
 

--- a/backend/grant/extensions.py
+++ b/backend/grant/extensions.py
@@ -5,9 +5,12 @@ from flask_marshmallow import Marshmallow
 from flask_migrate import Migrate
 from flask_security import Security
 from flask_sqlalchemy import SQLAlchemy
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 
 bcrypt = Bcrypt()
 db = SQLAlchemy()
 migrate = Migrate()
 ma = Marshmallow()
 security = Security()
+limiter = Limiter(key_func=get_remote_address)

--- a/backend/grant/user/views.py
+++ b/backend/grant/user/views.py
@@ -3,6 +3,7 @@ from flask import Blueprint, g
 from marshmallow import fields
 
 import grant.utils.auth as auth
+from grant.extensions import limiter
 from grant.comment.models import Comment, user_comments_schema
 from grant.email.models import EmailRecovery
 from grant.parser import query, body
@@ -89,6 +90,7 @@ def get_user(user_id, with_proposals, with_comments, with_funded, with_pending, 
 
 
 @blueprint.route("/", methods=["POST"])
+@limiter.limit("30/day;5/minute")
 @body({
     # TODO guard all (valid, minimum, maximum)
     "emailAddress": fields.Str(required=True),
@@ -207,6 +209,7 @@ def verify_user_social(service, code):
 
 
 @blueprint.route("/recover", methods=["POST"])
+@limiter.limit("10/day;2/minute")
 @body({
     "email": fields.Str(required=True)
 })
@@ -239,6 +242,7 @@ def recover_email(code, password):
 
 
 @blueprint.route("/avatar", methods=["POST"])
+@limiter.limit("20/day;3/minute")
 @auth.requires_auth
 @body({
     "mimetype": fields.Str(required=True)

--- a/backend/requirements/prod.txt
+++ b/backend/requirements/prod.txt
@@ -76,3 +76,6 @@ pyotp==2.2.7
 
 # JSON formatting
 animal_case==0.4.1
+
+# Rate limiting
+Flask-Limiter==1.0.1

--- a/backend/tests/config.py
+++ b/backend/tests/config.py
@@ -8,6 +8,7 @@ from grant.task.jobs import ProposalReminder
 from grant.user.models import User, SocialMedia, db, Avatar
 from grant.settings import PROPOSAL_STAKING_AMOUNT
 from grant.utils.enums import ProposalStatus
+from grant.extensions import limiter
 
 from .test_data import test_user, test_other_user, test_proposal, mock_blockchain_api_requests
 
@@ -17,6 +18,7 @@ class BaseTestConfig(TestCase):
     def create_app(self):
         app = create_app(['grant.settings', 'tests.settings'])
         app.config.from_object('tests.settings')
+        limiter.enabled = False
         return app
 
     def setUp(self):

--- a/frontend/client/components/ContributionModal/index.tsx
+++ b/frontend/client/components/ContributionModal/index.tsx
@@ -93,16 +93,17 @@ export default class ContributionModal extends React.Component<Props, State> {
           message="This contribution will not be attributed"
           description={
             <>
-              Your contribution will show up
-              without attribution. Even if you're logged in, the contribution will not appear anywhere
-              on your account after you close this modal.
+              Your contribution will show up without attribution. Even if you're logged
+              in, the contribution will not appear anywhere on your account after you
+              close this modal.
               <br /> <br />
-              ZF Grants is unable to offer refunds for non-attributed contributions. If refunds for this campaign are issued, your contribution will be treated as a donation to
-              the Zcash Foundation.
+              ZF Grants is unable to offer refunds for non-attributed contributions. If
+              refunds for this campaign are issued, your contribution will be treated as a
+              donation to the Zcash Foundation.
               <br /> <br />
-              If you would like to have your contribution attached to an account and remain eligible for refunds, you can
-              close this modal, make sure you're logged in, and don't check the
-              "Contribute without attribution" checkbox.
+              If you would like to have your contribution attached to an account and
+              remain eligible for refunds, you can close this modal, make sure you're
+              logged in, and don't check the "Contribute without attribution" checkbox.
             </>
           }
         />
@@ -134,16 +135,24 @@ export default class ContributionModal extends React.Component<Props, State> {
       if (error) {
         okText = 'Done';
         onOk = handleClose;
-        content = (
-          <Result
-            type="error"
-            title="Something went wrong"
-            description={`
-              We were unable to get your contribution started. Please check back
-              soon, we're working to fix the problem as soon as possible.
-            `}
-          />
-        );
+        // This should probably key on non-display text, but oh well.
+        let title;
+        let description;
+        if (error.includes('too many times')) {
+          title = 'Take it easy!';
+          description = `
+            We appreciate your enthusiasm, but you've made too many
+            contributions too fast. Please wait for your other contributions,
+            and try again later.
+          `;
+        } else {
+          title = 'Something went wrong';
+          description = `
+            We were unable to get your contribution started. Please check back
+            soon, we're working to fix the problem as soon as possible.
+          `;
+        }
+        content = <Result type="error" title={title} description={description} />;
       } else {
         okText = 'I’ve sent it';
         onOk = this.confirmSend;

--- a/frontend/client/components/CreateFlow/Team.tsx
+++ b/frontend/client/components/CreateFlow/Team.tsx
@@ -51,9 +51,10 @@ class CreateFlowTeam extends React.Component<Props, State> {
 
   render() {
     const { team, invites, address } = this.state;
-    const inviteError = address && !isValidEmail(address) &&
-      'That doesn’t look like a valid email address';
-    const inviteDisabled = !!inviteError || !address;
+    const inviteError =
+      address && !isValidEmail(address) && 'That doesn’t look like a valid email address';
+    const maxedOut = invites.length >= MAX_TEAM_SIZE - 1;
+    const inviteDisabled = !!inviteError || !address || maxedOut;
     const pendingInvites = invites.filter(inv => inv.accepted === null);
 
     return (
@@ -79,39 +80,39 @@ class CreateFlowTeam extends React.Component<Props, State> {
             ))}
           </div>
         )}
-        {team.length < MAX_TEAM_SIZE && (
-          <div className="TeamForm-add">
-            <h3 className="TeamForm-add-title">Add a team member</h3>
-            <Form className="TeamForm-add-form" onSubmit={this.handleAddSubmit}>
-              <Form.Item
-                className="TeamForm-add-form-field"
-                validateStatus={inviteError ? 'error' : undefined}
-                help={
-                  inviteError ||
-                  'They will be notified and will have to accept the invitation before being added'
-                }
-              >
-                <Input
-                  className="TeamForm-add-form-field-input"
-                  placeholder="Email address"
-                  size="large"
-                  value={address}
-                  onChange={this.handleChangeInviteAddress}
-                />
-              </Form.Item>
-              <Button
-                className="TeamForm-add-form-submit"
-                type="primary"
-                disabled={inviteDisabled}
-                htmlType="submit"
-                icon="user-add"
+        <div className="TeamForm-add">
+          <h3 className="TeamForm-add-title">Add a team member</h3>
+          <Form className="TeamForm-add-form" onSubmit={this.handleAddSubmit}>
+            <Form.Item
+              className="TeamForm-add-form-field"
+              validateStatus={inviteError ? 'error' : undefined}
+              help={
+                inviteError ||
+                (maxedOut && 'You’ve invited the maximum number of teammates') ||
+                'They will be notified and will have to accept the invitation before being added'
+              }
+            >
+              <Input
+                className="TeamForm-add-form-field-input"
+                placeholder="Email address"
                 size="large"
-              >
-                Add
-              </Button>
-            </Form>
-          </div>
-        )}
+                value={address}
+                onChange={this.handleChangeInviteAddress}
+                disabled={maxedOut}
+              />
+            </Form.Item>
+            <Button
+              className="TeamForm-add-form-submit"
+              type="primary"
+              disabled={inviteDisabled}
+              htmlType="submit"
+              icon="user-add"
+              size="large"
+            >
+              Add
+            </Button>
+          </Form>
+        </div>
       </div>
     );
   }
@@ -133,7 +134,7 @@ class CreateFlowTeam extends React.Component<Props, State> {
       })
       .catch((err: Error) => {
         console.error('Failed to send invite', err);
-        message.error('Failed to send invite', 3);
+        message.error(err.message, 3);
       });
   };
 
@@ -146,7 +147,7 @@ class CreateFlowTeam extends React.Component<Props, State> {
       })
       .catch((err: Error) => {
         console.error('Failed to remove invite', err);
-        message.error('Failed to remove invite', 3);
+        message.error(err.message, 3);
       });
   };
 }

--- a/frontend/client/components/DraftList/index.tsx
+++ b/frontend/client/components/DraftList/index.tsx
@@ -67,10 +67,10 @@ class DraftList extends React.Component<Props, State> {
       this.setState({ deletingId: null });
     }
     if (deleteDraftError && prevProps.deleteDraftError !== deleteDraftError) {
-      message.error('Failed to delete draft', 3);
+      message.error(deleteDraftError, 3);
     }
     if (createDraftError && prevProps.createDraftError !== createDraftError) {
-      message.error('Failed to create draft', 3);
+      message.error(createDraftError, 3);
     }
   }
 


### PR DESCRIPTION
Closes #140.

### What This Does

* First pass at rate limiting. Nothing fancy here, it's limits from `flask-limiter` that are based on IP. I'm sure some of this could be improved upon.
* Improves error messaging in some places.
* Prevents inviting more than the maximum team size.

### Steps to Test

* Create and test the limits of:
  * Drafts - 3/minute, 10/hour
  * Proposal team invites - 10/minute, 30/day
  * Contributions - 2/minute, 10/hour, 30/day
  * Proposal updates - 1/minute, 5/day
  * Comments - 2/minute, 30/hour, 100/day
* Try to invite more than 5 members to your team, confirm you can't
* Try to invite the same email twice, confirm you can't

## Screenshots

### Draft limit

<img width="568" alt="Screen Shot 2019-03-12 at 7 32 26 PM" src="https://user-images.githubusercontent.com/649992/54244719-356c8180-4504-11e9-8022-a5462495dd1f.png">

### Contribution limit

<img width="558" alt="Screen Shot 2019-03-12 at 7 55 53 PM" src="https://user-images.githubusercontent.com/649992/54244715-330a2780-4504-11e9-8de3-7d6fb1cbbad1.png">

### Update limit

<img width="824" alt="Screen Shot 2019-03-12 at 7 56 31 PM" src="https://user-images.githubusercontent.com/649992/54244712-300f3700-4504-11e9-9584-5df9e2b03c08.png">

### Signup limit

<img width="478" alt="Screen Shot 2019-03-12 at 7 57 29 PM" src="https://user-images.githubusercontent.com/649992/54244708-2d144680-4504-11e9-8675-2d8e693396c4.png">


### Max team invites & already invited

<img width="663" alt="Screen Shot 2019-03-12 at 8 05 02 PM" src="https://user-images.githubusercontent.com/649992/54244697-238ade80-4504-11e9-85ec-ca3e001edb71.png">

<img width="421" alt="Screen Shot 2019-03-12 at 8 05 41 PM" src="https://user-images.githubusercontent.com/649992/54244690-1f5ec100-4504-11e9-88b1-be1528a647bd.png">
