### PR TITLE
Slugify RFP urls

### DIFF
--- a/frontend/client/components/CreateFlow/Basics.tsx
+++ b/frontend/client/components/CreateFlow/Basics.tsx
@@ -81,7 +81,7 @@ class CreateFlowBasics extends React.Component<Props, State> {
             description={
               <>
                 This proposal is for the open request{' '}
-                <Link to={`/requests/${rfp.id}`} target="_blank">
+                <Link to={`/requests/${rfp.urlId}`} target="_blank">
                   {rfp.title}
                 </Link>
                 . If you didn’t mean to do this, or want to unlink it,{' '}

--- a/frontend/client/components/Proposal/RFPBlock/index.tsx
+++ b/frontend/client/components/Proposal/RFPBlock/index.tsx
@@ -12,7 +12,7 @@ const RFPBlock: React.SFC<Props> = ({ rfp }) => {
     <div className="RFPBlock Proposal-top-side-block">
       <h2 className="Proposal-top-main-block-title">Request</h2>
       <div className="Proposal-top-main-block">
-        <Link className="RFPBlock-content" to={`/requests/${rfp.id}`}>
+        <Link className="RFPBlock-content" to={`/requests/${rfp.urlId}`}>
           <h3 className="RFPBlock-content-title">{rfp.title}</h3>
           <div className="RFPBlock-content-brief">{rfp.brief}</div>
         </Link>

--- a/frontend/client/components/RFPs/RFPItem.tsx
+++ b/frontend/client/components/RFPs/RFPItem.tsx
@@ -16,7 +16,7 @@ export default class RFPItem extends React.Component<Props> {
   render() {
     const { rfp, isSmall } = this.props;
     const {
-      id,
+      urlId,
       title,
       brief,
       acceptedProposals,
@@ -49,7 +49,7 @@ export default class RFPItem extends React.Component<Props> {
     return (
       <Link
         className={classnames('RFPItem', isSmall && 'is-small')}
-        to={`/requests/${id}`}
+        to={`/requests/${urlId}`}
       >
         <h3 className="RFPItem-title">
           {title}

--- a/frontend/client/utils/api.ts
+++ b/frontend/client/utils/api.ts
@@ -105,6 +105,7 @@ export function formatProposalFromGet(p: any): Proposal {
 }
 
 export function formatRFPFromGet(rfp: RFP): RFP {
+  rfp.urlId = generateSlugUrl(rfp.id, rfp.title);
   if (rfp.bounty) {
     rfp.bounty = toZat(rfp.bounty as any);
   }

--- a/frontend/types/rfp.ts
+++ b/frontend/types/rfp.ts
@@ -4,6 +4,7 @@ import { Zat } from 'utils/units';
 
 export interface RFP {
   id: number;
+  urlId: string;
   title: string;
   brief: string;
   content: string;


### PR DESCRIPTION
Closes #168. Very straightforward, just make sure all the RFP links look correct and resolve to the correct RFP.