### PR TITLE
HeaderDetails on proposals and RFPs

### DIFF
--- a/frontend/client/components/Proposal/index.tsx
+++ b/frontend/client/components/Proposal/index.tsx
@@ -12,6 +12,7 @@ import { STATUS } from 'types';
 import { Tabs, Icon, Dropdown, Menu, Button, Alert } from 'antd';
 import { AlertProps } from 'antd/lib/alert';
 import ExceptionPage from 'components/ExceptionPage';
+import HeaderDetails from 'components/HeaderDetails';
 import CampaignBlock from './CampaignBlock';
 import TeamBlock from './TeamBlock';
 import RFPBlock from './RFPBlock';
@@ -164,6 +165,7 @@ export class ProposalDetail extends React.Component<Props, State> {
 
     return (
       <div className="Proposal">
+        <HeaderDetails title={proposal.title} description={proposal.brief} />
         {banner && (
           <div className="Proposal-banner">
             <Alert type={banner.type} message={banner.blurb} showIcon={false} banner />

--- a/frontend/client/components/RFP/index.tsx
+++ b/frontend/client/components/RFP/index.tsx
@@ -12,6 +12,7 @@ import Loader from 'components/Loader';
 import Markdown from 'components/Markdown';
 import ProposalCard from 'components/Proposals/ProposalCard';
 import UnitDisplay from 'components/UnitDisplay';
+import HeaderDetails from 'components/HeaderDetails';
 import './index.less';
 
 interface OwnProps {
@@ -67,6 +68,7 @@ class RFPDetail extends React.Component<Props> {
 
     return (
       <div className="RFPDetail">
+        <HeaderDetails title={rfp.title} description={rfp.brief} />
         <div className="RFPDetail-top">
           <Link className="RFPDetail-top-back" to="/requests">
             <Icon type="arrow-left" /> Back to Requests


### PR DESCRIPTION
Closes #351. Adds HeaderDetails to proposal pages and RFP pages.