### PR TITLE
Limit Contribution Related Emails

### DIFF
--- a/backend/grant/app.py
+++ b/backend/grant/app.py
@@ -4,7 +4,7 @@ import sentry_sdk
 import logging
 import traceback
 from animal_case import animalify
-from flask import Flask, Response, jsonify, request
+from flask import Flask, Response, jsonify, request, g
 from flask_cors import CORS
 from flask_security import SQLAlchemyUserDatastore
 from flask_sslify import SSLify
@@ -31,6 +31,13 @@ class JSONResponse(Response):
 def create_app(config_objects=["grant.settings"]):
     app = Flask(__name__.split(".")[0])
     app.response_class = JSONResponse
+
+    @app.after_request
+    def send_emails(response):
+        if 'email_sender' in g:
+            # starting email sender
+            g.email_sender.start()
+        return response
 
     # Return validation errors
     @app.errorhandler(ValidationException)

--- a/backend/grant/email/send.py
+++ b/backend/grant/email/send.py
@@ -7,7 +7,7 @@ from grant.settings import SENDGRID_API_KEY, SENDGRID_DEFAULT_FROM, SENDGRID_DEF
 from grant.settings import SENDGRID_API_KEY, SENDGRID_DEFAULT_FROM, UI, E2E_TESTING
 import sendgrid
 from threading import Thread
-from flask import render_template, Markup, current_app
+from flask import render_template, Markup, current_app, g
 
 
 default_template_args = {
@@ -351,9 +351,9 @@ def generate_email(type, email_args, user=None):
 
 
 def send_email(to, type, email_args):
-    mail = make_envelope(to, type, email_args)
-    if mail:
-        sendgrid_send(mail)
+    if 'email_sender' not in g:
+        g.email_sender = EmailSender(current_app._get_current_object())
+    g.email_sender.add(to, type, email_args)
 
 
 def make_envelope(to, type, email_args):

--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -7,7 +7,7 @@ from marshmallow import post_dump
 
 from flask import current_app
 from grant.comment.models import Comment
-from grant.email.send import send_email, EmailSender
+from grant.email.send import send_email
 from grant.extensions import ma, db
 from grant.utils.exceptions import ValidationException
 from grant.utils.misc import dt_to_unix, make_url, gen_random_id
@@ -525,19 +525,17 @@ class Proposal(db.Model):
         db.session.flush()
 
         # Send emails to team & contributors
-        email_sender = EmailSender(current_app._get_current_object())
         for u in self.team:
-            email_sender.add(u.email_address, 'proposal_canceled', {
+            send_email(u.email_address, 'proposal_canceled', {
                 'proposal': self,
                 'support_url': make_url('/contact'),
             })
         for u in self.contributors:
-            email_sender.add(u.email_address, 'contribution_proposal_canceled', {
+            send_email(u.email_address, 'contribution_proposal_canceled', {
                 'proposal': self,
                 'refund_address': u.settings.refund_address,
                 'account_settings_url': make_url('/profile/settings?tab=account')
             })
-        email_sender.start()
 
     @hybrid_property
     def contributed(self):

--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from decimal import Decimal
 from marshmallow import post_dump
 
+from flask import current_app
 from grant.comment.models import Comment
 from grant.email.send import send_email, EmailSender
 from grant.extensions import ma, db
@@ -524,20 +525,18 @@ class Proposal(db.Model):
         db.session.flush()
 
         # Send emails to team & contributors
-        email_sender = EmailSender()
+        email_sender = EmailSender(current_app._get_current_object())
         for u in self.team:
             email_sender.add(u.email_address, 'proposal_canceled', {
                 'proposal': self,
                 'support_url': make_url('/contact'),
             })
-        for c in self.contributions:
-            if c.user:
-                email_sender.add(c.user.email_address, 'contribution_proposal_canceled', {
-                    'contribution': c,
-                    'proposal': self,
-                    'refund_address': c.user.settings.refund_address,
-                    'account_settings_url': make_url('/profile/settings?tab=account')
-                })
+        for u in self.contributors:
+            email_sender.add(u.email_address, 'contribution_proposal_canceled', {
+                'proposal': self,
+                'refund_address': u.settings.refund_address,
+                'account_settings_url': make_url('/profile/settings?tab=account')
+            })
         email_sender.start()
 
     @hybrid_property
@@ -601,6 +600,11 @@ class Proposal(db.Model):
                     return ms
             return self.milestones[-1]  # return last one if all PAID
         return None
+
+    @hybrid_property
+    def contributors(self):
+        d = {c.user.id: c.user for c in self.contributions if c.user and c.status == ContributionStatus.CONFIRMED}
+        return d.values()
 
 
 class ProposalSchema(ma.Schema):

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -370,16 +370,14 @@ def post_proposal_update(proposal_id, title, content):
     db.session.add(update)
     db.session.commit()
 
-    # Send email to all contributors (even if contribution failed)
-    email_sender = EmailSender()
-    contributions = ProposalContribution.query.filter_by(proposal_id=proposal_id).all()
-    for c in contributions:
-        if c.user:
-            email_sender.add(c.user.email_address, 'contribution_update', {
-                'proposal': g.current_proposal,
-                'proposal_update': update,
-                'update_url': make_url(f'/proposals/{proposal_id}?tab=updates&update={update.id}'),
-            })
+    # Send email to all contributors
+    email_sender = EmailSender(current_app._get_current_object())
+    for u in g.current_proposal.contributors:
+        email_sender.add(u.email_address, 'contribution_update', {
+            'proposal': g.current_proposal,
+            'proposal_update': update,
+            'update_url': make_url(f'/proposals/{proposal_id}?tab=updates&update={update.id}'),
+        })
     email_sender.start()
 
     dumped_update = proposal_update_schema.dump(update)

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -8,7 +8,7 @@ from sentry_sdk import capture_message
 
 from grant.extensions import limiter
 from grant.comment.models import Comment, comment_schema, comments_schema
-from grant.email.send import send_email, EmailSender
+from grant.email.send import send_email
 from grant.milestone.models import Milestone
 from grant.parser import body, query, paginated_fields
 from grant.rfp.models import RFP
@@ -371,14 +371,12 @@ def post_proposal_update(proposal_id, title, content):
     db.session.commit()
 
     # Send email to all contributors
-    email_sender = EmailSender(current_app._get_current_object())
     for u in g.current_proposal.contributors:
-        email_sender.add(u.email_address, 'contribution_update', {
+        send_email(u.email_address, 'contribution_update', {
             'proposal': g.current_proposal,
             'proposal_update': update,
             'update_url': make_url(f'/proposals/{proposal_id}?tab=updates&update={update.id}'),
         })
-    email_sender.start()
 
     dumped_update = proposal_update_schema.dump(update)
     return dumped_update, 201

--- a/backend/grant/task/jobs.py
+++ b/backend/grant/task/jobs.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from grant.extensions import db
-from grant.email.send import send_email, EmailSender
+from grant.email.send import send_email
 from grant.utils.enums import ProposalStage, ContributionStatus
 from grant.utils.misc import make_url
 from flask import current_app
@@ -73,18 +73,16 @@ class ProposalDeadline:
         db.session.commit()
 
         # Send emails to team & contributors
-        email_sender = EmailSender(current_app._get_current_object())
         for u in proposal.team:
-            email_sender.add(u.email_address, 'proposal_failed', {
+            send_email(u.email_address, 'proposal_failed', {
                 'proposal': proposal,
             })
         for u in proposal.contributors:
-            email_sender.add(u.email_address, 'contribution_proposal_failed', {
+            send_email(u.email_address, 'contribution_proposal_failed', {
                 'proposal': proposal,
                 'refund_address': u.settings.refund_address,
                 'account_settings_url': make_url('/profile/settings?tab=account')
             })
-        email_sender.start()
 
 
 class ContributionExpired:

--- a/backend/grant/templates/emails/contribution_update.html
+++ b/backend/grant/templates/emails/contribution_update.html
@@ -1,24 +1,33 @@
 <p style="margin: 0 0 20px;">
-    A proposal you follow, <strong>{{ args.proposal.title }}</strong>, has
-    posted an update entitled "<strong>{{ args.proposal_update.title }}</strong>"
+  A proposal you contributed to, <strong>{{ args.proposal.title }}</strong
+  >, has posted an update entitled "<strong>{{
+    args.proposal_update.title
+  }}</strong
+  >"
 </p>
 
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
-    <tr>
-        <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
-            <table border="0" cellspacing="0" cellpadding="0">
-                <tr>
-                    <td align="center" style="border-radius: 3px;" bgcolor="{{ UI.PRIMARY }}">
-                        <a
-                            href="{{ args.update_url }}"
-                            target="_blank"
-                            style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{ UI.PRIMARY }}; display: inline-block;"
-                        >
-                            Read the Update
-                        </a>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
+  <tr>
+    <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
+      <table border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td
+            align="center"
+            style="border-radius: 3px;"
+            bgcolor="{{ UI.PRIMARY }}"
+          >
+            <a
+              href="{{ args.update_url }}"
+              target="_blank"
+              style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{
+                UI.PRIMARY
+              }}; display: inline-block;"
+            >
+              Read the Update
+            </a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
 </table>

--- a/backend/grant/templates/emails/contribution_update.txt
+++ b/backend/grant/templates/emails/contribution_update.txt
@@ -1,4 +1,4 @@
-A proposal you follow, "{{ args.proposal.title }}", has posted an update
+A proposal you contributed to, "{{ args.proposal.title }}", has posted an update
 entitled "{{ args.proposal_update.title }}".
 
 Go here to read it: {{ args.update_url }}


### PR DESCRIPTION
Closes #347.

### What this does
- emails related to contributions limited to one-per-contributor, and contributions with status CONFIRMED
- added `Proposal.contributors` hybrid field that produces users who have > 1 CONFIRMED contributions to proposal instance
- EmailSender constructor now takes in `app` since the logging now requires `current_app` which is missing when a new Thread is created
- 🆕 EmailSender is now set up automatically and stored on the request context object `g`, an ` @app.after_request` function is then used to start the EmailSender if it exists

### Notes
- ~~passing the `current_app` into `EmailSender` is getting a little intense, it might be good to figure out how to create the `EmailSender` object implicitly (automagically) at the beginning of a request and then `start()` it after each request. And have all `send_email` calls just add to the list.~~ <-- Implemented!

### Test

- for each proposal you will want to fund it three times from the same user, one of those times anonymously

**Proposal Failed**
- create a proposal, and fund it three times, diddle the `task.execute_after` field to the past and hit 
- look at backend logs, the email send logs should come after the endpoint logging
- there should only be one email for the user even though they made more than one contribution 

**Proposal Canceled**
- create a proposal and contribute to it the three times
- cancel it through the admin interface
- look at backend logs, the email send logs should come after the endpoint logging for proposal cancel
- there should only be one email for the user even though they made more than one contribution

**Proposal Updates**
- successfully fund a proposal making the three contributions
- as a team member, go to proposal detail and create an update
- observe the same pattern of email logs coming after endpoint logs
- there should only be one email for the user even though they made more than one contribution




