### PR TITLE
Render n/a when publishedDate is 0 (Admin)

### DIFF
--- a/admin/src/components/ProposalDetail/index.tsx
+++ b/admin/src/components/ProposalDetail/index.tsx
@@ -422,7 +422,10 @@ class ProposalDetailNaked extends React.Component<Props, State> {
             <Card title="Details" size="small">
               {renderDeetItem('id', p.proposalId)}
               {renderDeetItem('created', formatDateSeconds(p.dateCreated))}
-              {renderDeetItem('published', formatDateSeconds(p.datePublished))}
+              {renderDeetItem(
+                'published',
+                p.datePublished ? formatDateSeconds(p.datePublished) : 'n/a',
+              )}
               {renderDeetItem(
                 'deadlineDuration',
                 formatDurationSeconds(p.deadlineDuration),


### PR DESCRIPTION
Closes #339.

### What!
This sets the 'published' field in the Details section of proposal detail on admin to 'n/a' when it is 0. I opted to keep the field there since it is not derived.

### Test!
- go to any unpublished proposal detail in admin and notice the "published" Details item is shown as "n/a"
    ![Screen Shot 2019-03-14 at 11 16 17 AM](https://user-images.githubusercontent.com/11430954/54373462-483d9e00-464b-11e9-8967-b4efc2538a10.png)
- go to any live proposal, the published field should show formatted date
