### PR TITLE
Testnet banner

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -21,3 +21,6 @@ PROPOSAL_STAKING_AMOUNT=0.025
 
 # Normally production runs with SSL, this disables that
 DISABLE_SSL=true
+
+# Uncomment if running on testnet
+# TESTNET=true

--- a/frontend/client/components/Header/index.tsx
+++ b/frontend/client/components/Header/index.tsx
@@ -60,7 +60,7 @@ export default class Header extends React.Component<Props, State> {
 
           <HeaderDrawer isOpen={isDrawerOpen} onClose={this.closeDrawer} />
 
-          {!process.env.TESTNET && (
+          {process.env.TESTNET && (
             <div className="Header-testnet">
               <span>Testnet</span>
             </div>

--- a/frontend/client/components/Header/index.tsx
+++ b/frontend/client/components/Header/index.tsx
@@ -59,6 +59,12 @@ export default class Header extends React.Component<Props, State> {
           </div>
 
           <HeaderDrawer isOpen={isDrawerOpen} onClose={this.closeDrawer} />
+
+          {!process.env.TESTNET && (
+            <div className="Header-testnet">
+              <span>Testnet</span>
+            </div>
+          )}
         </div>
       </div>
     );

--- a/frontend/client/components/Header/style.less
+++ b/frontend/client/components/Header/style.less
@@ -121,4 +121,41 @@
       }
     }
   }
+
+  &-testnet {
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    height: 1.4rem;
+    line-height: 1.4rem;
+    padding: 0 0.5rem;
+    transform: translate(-50%, 50%);
+    text-align: center;
+    border-radius: 1rem;
+    border: 1px solid rgba(#000, 0.1);
+    color: rgba(#000, 0.6);
+    background: #FFF;
+    text-transform: uppercase;
+    letter-spacing: 0.9rem;
+    font-size: 11px;
+    font-weight: bold;
+    transition: @header-transition ease;
+
+    > span {
+      display: inline-block;
+      transform: translateX(0.42rem);
+    }
+  }
+  &.is-transparent {
+    .Header-testnet {
+      transform: translate(-50%, 120%);
+      letter-spacing: 1.5rem;
+      border: none;
+
+      > span {
+        display: inline-block;
+        transform: translateX(0.55rem);
+      }
+    }
+  }
 }

--- a/frontend/client/components/Header/style.less
+++ b/frontend/client/components/Header/style.less
@@ -45,6 +45,7 @@
     flex-grow: 1;
     text-align: center;
     opacity: 0.7;
+    z-index: 222;
 
     &:hover,
     &:focus {
@@ -132,30 +133,23 @@
     transform: translate(-50%, 50%);
     text-align: center;
     border-radius: 1rem;
-    border: 1px solid rgba(#000, 0.1);
+    box-shadow: 0 0 0 1px rgba(#000, 0.1);
     color: rgba(#000, 0.6);
     background: #FFF;
     text-transform: uppercase;
     letter-spacing: 0.9rem;
-    font-size: 11px;
+    font-size: 0.65rem;
     font-weight: bold;
-    transition: @header-transition ease;
+    transition: opacity @header-transition ease;
+    z-index: 111;
 
     > span {
       display: inline-block;
       transform: translateX(0.42rem);
     }
-  }
-  &.is-transparent {
-    .Header-testnet {
-      transform: translate(-50%, 120%);
-      letter-spacing: 1.5rem;
-      border: none;
 
-      > span {
-        display: inline-block;
-        transform: translateX(0.55rem);
-      }
+    .is-transparent & {
+      opacity: 0;
     }
   }
 }

--- a/frontend/config/env.js
+++ b/frontend/config/env.js
@@ -53,13 +53,14 @@ process.env.NODE_PATH = (process.env.NODE_PATH || '')
 module.exports = () => {
   const raw = {
     BACKEND_URL: process.env.BACKEND_URL || 'http://localhost:5000',
-    EXPLORER_URL: process.env.EXPLORER_URL || 'https://chain.so/zcash/',
+    EXPLORER_URL: process.env.EXPLORER_URL || 'https://explorer.zcha.in/',
     NODE_ENV: process.env.NODE_ENV || 'development',
     PORT: process.env.PORT || 3000,
     PROPOSAL_STAKING_AMOUNT: process.env.PROPOSAL_STAKING_AMOUNT,
     PUBLIC_HOST_URL: process.env.PUBLIC_HOST_URL,
     SENTRY_DSN: process.env.SENTRY_DSN || null,
     SENTRY_RELEASE: process.env.SENTRY_RELEASE || undefined,
+    TESTNET: process.env.TESTNET || false,
   };
 
   // Stringify all values so we can feed into Webpack DefinePlugin


### PR DESCRIPTION
Adds a banner to the header (except on homepage) that indicates we're on testnet. Requires `TESTNET=true` in .env to show up.

<img width="221" alt="Screen Shot 2019-03-14 at 3 30 21 PM" src="https://user-images.githubusercontent.com/649992/54385917-2275c080-466e-11e9-9f63-bbe89fd45e2c.png">
