### PR TITLE
Several bugs

### DIFF
--- a/admin/src/components/ProposalDetail/index.less
+++ b/admin/src/components/ProposalDetail/index.less
@@ -18,7 +18,7 @@
       font-size: 0.7rem;
       position: absolute;
       opacity: 0.8;
-      top: 1rem;
+      bottom: -0.7rem;
     }
   }
 

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -142,7 +142,7 @@ def post_proposal_comments(proposal_id, comment, parent_comment_id):
             send_email(member.email_address, 'proposal_comment', {
                 'author': g.current_user,
                 'proposal': proposal,
-                'comment_url': make_url(f'/proposal/{proposal.id}?tab=discussions&comment={comment.id}'),
+                'comment_url': make_url(f'/proposals/{proposal.id}?tab=discussions&comment={comment.id}'),
                 'author_url': make_url(f'/profile/{comment.author.id}'),
             })
     # Email parent comment creator, if it's not themselves
@@ -150,7 +150,7 @@ def post_proposal_comments(proposal_id, comment, parent_comment_id):
         send_email(parent.author.email_address, 'comment_reply', {
             'author': g.current_user,
             'proposal': proposal,
-            'comment_url': make_url(f'/proposal/{proposal.id}?tab=discussions&comment={comment.id}'),
+            'comment_url': make_url(f'/proposals/{proposal.id}?tab=discussions&comment={comment.id}'),
             'author_url': make_url(f'/profile/{comment.author.id}'),
         })
 

--- a/backend/grant/user/views.py
+++ b/backend/grant/user/views.py
@@ -273,7 +273,7 @@ def delete_avatar(url):
     "displayName": fields.Str(required=True, validate=lambda d: 2 <= len(d) <= 60),
     "title": fields.Str(required=True, validate=lambda t: 2 <= len(t) <= 60),
     "socialMedias": fields.List(fields.Dict(), required=True),
-    "avatar": fields.Str(required=True, validate=lambda d: validators.url(d))
+    "avatar": fields.Str(required=True, allow_none=True, validate=lambda d: validators.url(d))
 })
 def update_user(user_id, display_name, title, social_medias, avatar):
     user = g.current_user

--- a/frontend/client/components/CreateFlow/Basics.tsx
+++ b/frontend/client/components/CreateFlow/Basics.tsx
@@ -81,7 +81,7 @@ class CreateFlowBasics extends React.Component<Props, State> {
             description={
               <>
                 This proposal is for the open request{' '}
-                <Link to={`/requests/${rfp.urlId}`} target="_blank">
+                <Link to={`/requests/${rfp.id}`} target="_blank">
                   {rfp.title}
                 </Link>
                 . If you didn’t mean to do this, or want to unlink it,{' '}


### PR DESCRIPTION
Closes #375. Closes #371. Closes #368. Closes #367.

### What this does
- #375 adjust CSS for ProposalDetail Details values/labels such that the label is anchored to the bottom of the div instead of the top so it avoids overlapping with the value in the event that the value is long enough to wrap
- #371 adjust the urls sent out in the comment_reply & proposal_comment emails
- #368 allow_none=True for /user/<id> PUT end-point validation so we can successfully remove avatar
- #367 use `rfp.id` in link from proposal (creation step) to RFP

### Test
#375
- create a proposal and set an arbiter for it who's display name is long enough to wrap
- visit the proposal detail view in admin
- observe that the "arbiter" field of in Detail card wraps and that the label stays below the value
    ![Screen Shot 2019-03-14 at 8 41 39 PM](https://user-images.githubusercontent.com/11430954/54402315-9a0d1500-4699-11e9-8ead-bdc4a6e7333d.png)

#371 
- comment on a proposal, check that the "View their comment" button link sends you to the proposal and not a 404

#368 
- add an avatar to a user, then try to remove the avatar, it should successfully remove the avatar

#367 
- from an RFP create a proposal
- on the first step attempt to click the link inside the alert box
- ensure it successfully loads the RFP in a new tab
![Screen Shot 2019-03-14 at 8 46 08 PM](https://user-images.githubusercontent.com/11430954/54402593-91690e80-469a-11e9-9981-82dd967f280f.png)



