### PR TITLE
Repeat bootstrap attempts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Create an application instance."""
+from flask import request
 from grant.app import create_app
 from grant.blockchain.bootstrap import send_bootstrap_data
 
@@ -8,6 +9,10 @@ app = create_app()
 
 @app.before_first_request
 def bootstrap_watcher():
+    # Don't call bootstrap if the first request to us was bootstrap
+    if 'blockchain/bootstrap' in request.path:
+        return
+
     try:
         send_bootstrap_data()
     except:

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,19 +1,5 @@
 # -*- coding: utf-8 -*-
 """Create an application instance."""
-from flask import request
 from grant.app import create_app
-from grant.blockchain.bootstrap import send_bootstrap_data
 
 app = create_app()
-
-
-@app.before_first_request
-def bootstrap_watcher():
-    # Don't call bootstrap if the first request to us was bootstrap
-    if 'blockchain/bootstrap' in request.path:
-        return
-
-    try:
-        send_bootstrap_data()
-    except:
-        print('Failed to send bootstrap data, watcher must be offline')

--- a/blockchain/src/index.ts
+++ b/blockchain/src/index.ts
@@ -16,7 +16,7 @@ async function start() {
   log.info("============== Starting services ==============");
   await initNode();
   await RestServer.start();
-  await Webhooks.start();
+  Webhooks.start();
   log.info("===============================================");
 }
 

--- a/blockchain/src/webhooks/index.ts
+++ b/blockchain/src/webhooks/index.ts
@@ -17,7 +17,13 @@ const MIN_BLOCK_CONF = parseInt(env.MINIMUM_BLOCK_CONFIRMATIONS, 10);
 export async function start() {
   initScan();
   initNotifiers();
-  await requestBootstrap();
+
+  let { startingBlockHeight } = store.getState();
+  while (!startingBlockHeight) {
+    await requestBootstrap();
+    await sleep(10000);
+    startingBlockHeight = store.getState().startingBlockHeight;
+  }
 }
 
 export function exit() {


### PR DESCRIPTION
Closes #370. Switches the bootstrapping from being this he-says-she-says between both backend and watcher, to some good ol' long polling from the watcher. Should have been this way from the start, much simpler!

To test, just try it out in a few ways:
* Start the watcher, wait a bit, then start the backend. Confirm the watcher bootstraps  again shortly.
* Start the backend, wait a bit, then start the watcher. Confirm the watcher bootstraps immediately.