### PR TITLE
String replacement for block explorer URL

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,8 +29,8 @@ BLOCKCHAIN_REST_API_URL="http://localhost:5051"
 BLOCKCHAIN_API_SECRET="ef0b48e41f78d3ae85b1379b386f1bca"
 
 # Blockchain explorer to link to. Top for mainnet, bottom for testnet.
-# EXPLORER_URL="https://explorer.zcha.in/"
-EXPLORER_URL="https://testnet.zcha.in/"
+# EXPLORER_URL="https://chain.so/tx/ZECTEST/<txid>"
+EXPLORER_URL="https://chain.so/tx/ZECTEST/<txid>"
 
 # Amount for staking a proposal in ZEC
 PROPOSAL_STAKING_AMOUNT=0.025

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,7 +29,7 @@ BLOCKCHAIN_REST_API_URL="http://localhost:5051"
 BLOCKCHAIN_API_SECRET="ef0b48e41f78d3ae85b1379b386f1bca"
 
 # Blockchain explorer to link to. Top for mainnet, bottom for testnet.
-# EXPLORER_URL="https://chain.so/tx/ZECTEST/<txid>"
+# EXPLORER_URL="https://chain.so/tx/ZEC/<txid>"
 EXPLORER_URL="https://chain.so/tx/ZECTEST/<txid>"
 
 # Amount for staking a proposal in ZEC

--- a/backend/grant/admin/views.py
+++ b/backend/grant/admin/views.py
@@ -24,7 +24,6 @@ from grant.proposal.models import (
     admin_proposal_contributions_schema,
 )
 from grant.rfp.models import RFP, admin_rfp_schema, admin_rfps_schema
-from grant.settings import EXPLORER_URL
 from grant.user.models import User, UserSettings, admin_users_schema, admin_user_schema
 from grant.utils import pagination
 from grant.utils.enums import Category
@@ -36,7 +35,7 @@ from grant.utils.enums import (
     MilestoneStage,
     RFPStatus,
 )
-from grant.utils.misc import make_url
+from grant.utils.misc import make_url, make_explore_url
 from .example_emails import example_email_args
 
 blueprint = Blueprint('admin', __name__, url_prefix='/api/v1/admin')
@@ -434,7 +433,7 @@ def paid_milestone_payout_request(id, mid, tx_id):
                     'proposal': proposal,
                     'milestone': ms,
                     'amount': amount,
-                    'tx_explorer_url': f'{EXPLORER_URL}transactions/{tx_id}',
+                    'tx_explorer_url': make_explore_url(tx_id),
                     'proposal_milestones_url': make_url(f'/proposals/{proposal.id}?tab=milestones'),
                 })
             return proposal_schema.dump(proposal), 200

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -11,7 +11,7 @@ from grant.email.send import send_email
 from grant.milestone.models import Milestone
 from grant.parser import body, query, paginated_fields
 from grant.rfp.models import RFP
-from grant.settings import EXPLORER_URL, PROPOSAL_STAKING_AMOUNT
+from grant.settings import PROPOSAL_STAKING_AMOUNT
 from grant.task.jobs import ProposalDeadline
 from grant.user.models import User
 from grant.utils import pagination
@@ -26,7 +26,7 @@ from grant.utils.auth import (
 from grant.utils.enums import Category
 from grant.utils.enums import ProposalStatus, ProposalStage, ContributionStatus
 from grant.utils.exceptions import ValidationException
-from grant.utils.misc import is_email, make_url, from_zat
+from grant.utils.misc import is_email, make_url, from_zat, make_explore_url
 from .models import (
     Proposal,
     proposals_schema,
@@ -542,7 +542,7 @@ def post_contribution_confirmation(contribution_id, to, amount, txid):
         send_email(contribution.user.email_address, 'staking_contribution_confirmed', {
             'contribution': contribution,
             'proposal': contribution.proposal,
-            'tx_explorer_url': f'{EXPLORER_URL}transactions/{txid}',
+            'tx_explorer_url': make_explore_url(txid),
             'fully_staked': contribution.proposal.is_staked,
             'stake_target': str(PROPOSAL_STAKING_AMOUNT.normalize()),
         })
@@ -553,7 +553,7 @@ def post_contribution_confirmation(contribution_id, to, amount, txid):
             send_email(contribution.user.email_address, 'contribution_confirmed', {
                 'contribution': contribution,
                 'proposal': contribution.proposal,
-                'tx_explorer_url': f'{EXPLORER_URL}transactions/{txid}',
+                'tx_explorer_url': make_explore_url(txid),
             })
 
         # Send to the full proposal gang

--- a/backend/grant/settings.py
+++ b/backend/grant/settings.py
@@ -58,7 +58,7 @@ LINKEDIN_CLIENT_SECRET = env.str("LINKEDIN_CLIENT_SECRET")
 BLOCKCHAIN_REST_API_URL = env.str("BLOCKCHAIN_REST_API_URL")
 BLOCKCHAIN_API_SECRET = env.str("BLOCKCHAIN_API_SECRET")
 
-EXPLORER_URL = env.str("EXPLORER_URL", default="https://explorer.zcha.in/")
+EXPLORER_URL = env.str("EXPLORER_URL", default="https://chain.so/tx/ZECTEST/<txid>")
 
 PROPOSAL_STAKING_AMOUNT = Decimal(env.str("PROPOSAL_STAKING_AMOUNT"))
 

--- a/backend/grant/utils/misc.py
+++ b/backend/grant/utils/misc.py
@@ -4,7 +4,7 @@ import re
 import string
 import time
 
-from grant.settings import SITE_URL
+from grant.settings import SITE_URL, EXPLORER_URL
 
 epoch = datetime.datetime.utcfromtimestamp(0)
 RANDOM_CHARS = string.ascii_letters + string.digits
@@ -35,6 +35,10 @@ def clean_random_code(code: str):
 
 def make_url(path: str):
     return f'{SITE_URL}{path}'
+
+
+def make_explore_url(txid: str):
+    return EXPLORER_URL.replace('<txid>', txid)
 
 
 def is_email(email: str):

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -13,8 +13,8 @@ BACKEND_URL=http://localhost:5000
 # SENTRY_RELEASE="optional, provides sentry logging with release info"
 
 # Blockchain explorer to link to. Top for mainnet, bottom for testnet.
-# EXPLORER_URL="https://explorer.zcha.in/"
-EXPLORER_URL="https://testnet.zcha.in/"
+# EXPLORER_URL="https://chain.so/tx/ZECTEST/<txid>"
+EXPLORER_URL="https://chain.so/tx/ZECTEST/<txid>"
 
 # Amount for staking a proposal in ZEC
 PROPOSAL_STAKING_AMOUNT=0.025

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -13,7 +13,7 @@ BACKEND_URL=http://localhost:5000
 # SENTRY_RELEASE="optional, provides sentry logging with release info"
 
 # Blockchain explorer to link to. Top for mainnet, bottom for testnet.
-# EXPLORER_URL="https://chain.so/tx/ZECTEST/<txid>"
+# EXPLORER_URL="https://chain.so/tx/ZEC/<txid>"
 EXPLORER_URL="https://chain.so/tx/ZECTEST/<txid>"
 
 # Amount for staking a proposal in ZEC

--- a/frontend/client/utils/formatters.ts
+++ b/frontend/client/utils/formatters.ts
@@ -87,5 +87,8 @@ export function formatZcashCLI(address: string, amount?: string | number, memo?:
 }
 
 export function formatTxExplorerUrl(txid: string) {
-  return `${process.env.EXPLORER_URL}transactions/${txid}`;
+  if (process.env.EXPLORER_URL) {
+    return process.env.EXPLORER_URL.replace('<txid>', txid);
+  }
+  throw new Error('EXPLORER_URL env variable needs to be set!');
 }

--- a/frontend/config/env.js
+++ b/frontend/config/env.js
@@ -53,7 +53,7 @@ process.env.NODE_PATH = (process.env.NODE_PATH || '')
 module.exports = () => {
   const raw = {
     BACKEND_URL: process.env.BACKEND_URL || 'http://localhost:5000',
-    EXPLORER_URL: process.env.EXPLORER_URL || 'https://explorer.zcha.in/',
+    EXPLORER_URL: process.env.EXPLORER_URL || 'https://chain.so/tx/ZECTEST/<txid>',
     NODE_ENV: process.env.NODE_ENV || 'development',
     PORT: process.env.PORT || 3000,
     PROPOSAL_STAKING_AMOUNT: process.env.PROPOSAL_STAKING_AMOUNT,


### PR DESCRIPTION
### What it does
- uses string replacement for block explorer url, replacing `<txid>` with, yes, the txid
- adds _adapter_ function to backend for doing so `make_explore_url`

### Test
- trigger contribution confirmation on a proposal (may use admin but if you use a bad txid the link will not work)
    - check the emails and make sure the urls are correct
- check profile Funded tab "View transaction" links for confirmed contribs
- admin: pay a milestone payout (use a fake txid if you wish) make sure the email has correct URL format