### PR TITLE
Prevent brief from overflowing

### DIFF
--- a/frontend/client/components/Profile/ProfileInvite.less
+++ b/frontend/client/components/Profile/ProfileInvite.less
@@ -7,6 +7,9 @@
   margin-bottom: 1rem;
   
   &-info {
+    min-width: 0;
+    padding-right: 2rem;
+
     &-title {
       font-size: 1.2rem;
       font-weight: 600;

--- a/frontend/client/styles/antd-overrides.less
+++ b/frontend/client/styles/antd-overrides.less
@@ -16,3 +16,20 @@
 div.antd-pro-ellipsis-ellipsis {
   word-break: break-word;
 }
+
+// List items with long content can push the actions aside
+.ant-list-item {
+  overflow: hidden;
+
+  .ant-list-item-content,
+  .ant-list-item-meta,
+  .ant-list-item-meta-content {
+    min-width: 0;
+  }
+
+  .ant-list-item-meta-title,
+  .ant-list-item-meta-description {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}


### PR DESCRIPTION
Closes #398. Fixes a couple of cases where previously the brief of a proposal would push the actions off screen.

<img width="609" alt="Screen Shot 2019-03-18 at 12 24 46 PM" src="https://user-images.githubusercontent.com/649992/54546281-b8b12b80-4979-11e9-82b5-7495010ff216.png">

<img width="871" alt="Screen Shot 2019-03-18 at 12 24 40 PM" src="https://user-images.githubusercontent.com/649992/54546284-ba7aef00-4979-11e9-897e-4ea6fc1dd2ca.png">

Now they properly ellipsize.