### PR TITLE
Fix detail page milestone rehydration

### DIFF
--- a/frontend/client/utils/api.ts
+++ b/frontend/client/utils/api.ts
@@ -149,6 +149,10 @@ export function massageSerializedState(state: AppState) {
     );
     state.proposal.detail.contributionBounty = new BN((state.proposal.detail
       .contributionBounty as any) as string);
+    state.proposal.detail.milestones = state.proposal.detail.milestones.map(m => ({
+      ...m,
+      amount: new BN((m.amount as any) as string, 16),
+    }));
     if (state.proposal.detail.rfp && state.proposal.detail.rfp.bounty) {
       state.proposal.detail.rfp.bounty = new BN(
         (state.proposal.detail.rfp.bounty as any) as string,


### PR DESCRIPTION
Closes #397. Properly rehydrates hex bignumber milestones. To test, refresh a proposal detail page (with js disabled if you're having a hard time catching it) and confirm you don't see NaN for the milestone amount.