### PR TITLE
Enforce SSL on Admin

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -1,0 +1,8 @@
+# admin listen port
+PORT=3500
+
+# backend url
+BACKEND_URL=http://localhost:5000
+
+# Disable SSL in production
+# DISABLE_SSL=true

--- a/admin/.envexample
+++ b/admin/.envexample
@@ -1,4 +1,0 @@
-# admin listen port
-PORT=3500
-# backend url
-BACKEND_URL=http://localhost:5000

--- a/admin/package.json
+++ b/admin/package.json
@@ -68,6 +68,7 @@
     "dotenv": "^6.0.0",
     "ethereum-blockies-base64": "1.0.2",
     "ethereumjs-util": "5.2.0",
+    "express-sslify": "1.2.0",
     "file-loader": "^2.0.0",
     "font-awesome": "^4.7.0",
     "fork-ts-checker-webpack-plugin": "^0.4.2",

--- a/admin/server.js
+++ b/admin/server.js
@@ -1,9 +1,16 @@
 const express = require('express');
 const path = require('path');
+const enforce = require('express-sslify');
 
 require('dotenv').config();
+const isDev = process.env.NODE_ENV === 'development';
 const PORT = process.env.PORT || 3500;
 const app = express();
+
+if (!isDev && !process.env.DISABLE_SSL) {
+  console.log('PRODUCTION mode, enforcing HTTPS redirect');
+  app.use(enforce.HTTPS({ trustProtoHeader: true }));
+}
 
 app.use(express.static(__dirname + '/build'));
 

--- a/admin/yarn.lock
+++ b/admin/yarn.lock
@@ -3225,6 +3225,11 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
+express-sslify@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/express-sslify/-/express-sslify-1.2.0.tgz#30e84bceed1557eb187672bbe1430a0a2a100d9c"
+  integrity sha1-MOhLzu0VV+sYdnK74UMKCioQDZw=
+
 express@^4.16.2:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"

--- a/frontend/server/index.tsx
+++ b/frontend/server/index.tsx
@@ -29,7 +29,7 @@ const app = express();
 
 // ssl
 if (!isDev && !process.env.DISABLE_SSL) {
-  log.warn('PRODUCTION mode, enforcing HTTPS redirect');
+  log.info('PRODUCTION mode, enforcing HTTPS redirect');
   app.use(enforce.HTTPS({ trustProtoHeader: true }));
 }
 


### PR DESCRIPTION
Closes #389.

### What This Does

Adds `express-sslify` to admin, just like the frontend. A little bit of misc cleanup along the way as well.

### Steps to Test

* Run admin in dev mode, confirm you can go on https
* Run `yarn build && yarn start`, confirm you get forced onto https