### PR TITLE
Refresh page on chunk errors

### DIFF
--- a/frontend/client/components/ErrorScreen/index.tsx
+++ b/frontend/client/components/ErrorScreen/index.tsx
@@ -2,21 +2,36 @@ import React from 'react';
 import * as Sentry from '@sentry/browser';
 import { Button } from 'antd';
 import Exception from 'ant-design-pro/lib/Exception';
+import Loader from 'components/Loader';
 import './index.less';
 
 interface Props {
   error: Error;
 }
 
+const isChunkError = (err: Error) => {
+  return err.message.includes('Loading chunk');
+};
+
 export default class ErrorScreen extends React.PureComponent<Props> {
   componentDidMount() {
     const { error } = this.props;
-    Sentry.captureException(error);
-    console.error('Error screen showing due to the following error:', error);
+    if (isChunkError(error)) {
+      setTimeout(() => {
+        window.location.reload();
+      }, 500);
+    } else {
+      Sentry.captureException(error);
+      console.error('Error screen showing due to the following error:', error);
+    }
   }
 
   render() {
     const { error } = this.props;
+    if (isChunkError(error)) {
+      return <Loader size="large" />;
+    }
+
     return (
       <div className="ErrorScreen">
         <Exception


### PR DESCRIPTION
Closes #391 

### What This Does

The ErrorScreen component now shows a loader and refreshes on chunk errors, rather than displaying them to the user and reporting them to sentry. These usually either happen because of intermittent network failure, or a new version of the site was deployed with new chunk hashes. This shouldn't disrupt users since they would only encounter these errors while browsing to a new page anyway, so state isn't super important here.

### Steps to Test

* Run `yarn build && yarn start` and open a page.
* Open the network panel and go offline.
* Browse to a new page. Confirm you see a spinner for a half-second, and then the page refreshes.