### PR TITLE
Blockchain watcher safety adjustments

### DIFF
--- a/blockchain/src/node.ts
+++ b/blockchain/src/node.ts
@@ -17,9 +17,9 @@ export interface BlockChainInfo {
 export interface ScriptPubKey {
   asm: string;
   hex: string;
-  reqSigs: number;
   type: string;
-  addresses: string[];
+  reqSigs?: number;
+  addresses?: string[];
 }
 
 export interface VIn {

--- a/blockchain/src/webhooks/notifiers/contribution/index.ts
+++ b/blockchain/src/webhooks/notifiers/contribution/index.ts
@@ -42,6 +42,11 @@ export default class ContributionNotifier implements Notifier {
 
     block.tx.forEach(tx => {
       tx.vout.forEach(vout => {
+        // Some vouts are not transactions with addresses, ignore those
+        if (!vout.scriptPubKey.addresses) {
+          return;
+        }
+
         // Addresses is an array because of multisigs, but we'll never
         // generate one, so all of our addresses will only have addresses[0]
         const to = vout.scriptPubKey.addresses[0];


### PR DESCRIPTION
### What This Does

* Fixes uncaught errors from `node.getblockcount` in the scanBlock function causing silent failures
* Fixes an issue that may have caused blocks that failed to fetch from being skipped
* Fixes an issue where some vouts are not pubkeyhash transactions, and therefore do not have addresses
* Ups the retry interval after a failed block to 60 seconds from 5 seconds, to give the node more time to get ready
* Ups the number of retries to 10 from 5 before restarting the watcher

### Steps to Test

For the uncaught and block skip issues,
* Start up the watcher on a regtest node, then quickly kill the regtest node while it's scanning
* Confirm it warns about the failure, and tries again with a warning in 1 minute
* Start up the regtest node again, confirm it continues after 1 minute on the same block it failed on

For the vout issue,
* Start up the watcher on mainnet node on `develop`
* Set the starting block to 501620
* Confirm it crashes on 501628
* Start the watcher up again on this branch
* Confirm it works fine past 501628