### PR TITLE
Default target to '0'

### DIFF
--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -405,7 +405,7 @@ class Proposal(db.Model):
         self.brief = brief[:255]
         self.category = category
         self.content = content[:300000]
-        self.target = target[:255] if target != '' else None
+        self.target = target[:255] if target != '' else '0'
         self.payout_address = payout_address[:255]
         self.deadline_duration = deadline_duration
         Proposal.simple_validate(vars(self))

--- a/frontend/client/components/CreateFlow/Basics.tsx
+++ b/frontend/client/components/CreateFlow/Basics.tsx
@@ -68,6 +68,12 @@ class CreateFlowBasics extends React.Component<Props, State> {
     const { title, brief, category, target, rfp, rfpOptIn } = this.state;
     const errors = getCreateErrors(this.state, true);
 
+    // Don't show target error at zero since it defaults to that
+    // Error just shows up at the end to prevent submission
+    if (target === '0') {
+      errors.target = undefined;
+    }
+
     const rfpOptInRequired =
       rfp && (rfp.matching || (rfp.bounty && new BN(rfp.bounty).gtn(0)));
 

--- a/frontend/client/modules/create/utils.ts
+++ b/frontend/client/modules/create/utils.ts
@@ -107,7 +107,7 @@ export function getCreateErrors(
   const targetFloat = target ? parseFloat(target) : 0;
   if (target && !Number.isNaN(targetFloat)) {
     const limit = parseFloat(process.env.PROPOSAL_TARGET_MAX as string);
-    const targetErr = getAmountError(targetFloat, limit);
+    const targetErr = getAmountError(targetFloat, limit, 1);
     if (targetErr) {
       errors.target = targetErr;
     }

--- a/frontend/client/utils/validators.ts
+++ b/frontend/client/utils/validators.ts
@@ -1,4 +1,4 @@
-export function getAmountError(amount: number, max: number = Infinity) {
+export function getAmountError(amount: number, max: number = Infinity, min?: number) {
   if (amount < 0) {
     return 'Amount must be a positive number';
   } else if (
@@ -8,6 +8,8 @@ export function getAmountError(amount: number, max: number = Infinity) {
     return 'Must be in increments of 0.001';
   } else if (amount > max) {
     return `Cannot exceed maximum (${max} ZEC)`;
+  } else if (min && amount < min) {
+    return `Must be at least ${min} ZEC`;
   }
 
   return null;


### PR DESCRIPTION
Closes #390.

### What This Does

Defaults target to '0' instead of None due to db not-null constraint, and the use of `Decimal` everywhere throwing on empty string. Also adds some frontend validation to avoid users attempting to submit with '0' (It would error on the backend, but no warning on the frontend.)

Had to do a little hack to not show an error immediately on the basics screen since it defaults to an invalid value, but I think it's a pretty minor sin.