### PR TITLE
upgrade jinja for security

### DIFF
--- a/backend/requirements/prod.txt
+++ b/backend/requirements/prod.txt
@@ -4,7 +4,7 @@
 Flask==1.0.2
 MarkupSafe==1.0
 Werkzeug==0.14.1
-Jinja2==2.10
+Jinja2==2.10.1
 itsdangerous==0.24
 click>=5.0
 


### PR DESCRIPTION
Jinja 2.10 has a security issue, this just upgrades to the patched version.