### PR TITLE
Proposal funding precision

### DIFF
--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -1,5 +1,5 @@
 import datetime
-from decimal import Decimal
+from decimal import Decimal, ROUND_DOWN
 from functools import reduce
 
 from flask import current_app
@@ -611,7 +611,6 @@ class Proposal(db.Model):
 
     @hybrid_property
     def funded(self):
-
         target = Decimal(self.target)
         # apply matching multiplier
         funded = Decimal(self.contributed) * Decimal(1 + self.contribution_matching)
@@ -620,9 +619,9 @@ class Proposal(db.Model):
             funded = funded + Decimal(self.contribution_bounty)
         # if funded > target, just set as target
         if funded > target:
-            return str(target)
+            return str(target.quantize(Decimal('.001'), rounding=ROUND_DOWN))
 
-        return str(funded)
+        return str(funded.quantize(Decimal('.001'), rounding=ROUND_DOWN))
 
     @hybrid_property
     def is_staked(self):


### PR DESCRIPTION
Closes #425.

### What this does
- truncates by rounding down the precision of proposal.funded (to match FE increment precision)

### Test
- create and stake a proposal
- create a contribution for the proposal
- from admin, alter the contribution amount to 0.0011111 & set a txid on it
- attempt to contribute the remaining amount to the proposal, confirm that you can do so and that the displayed funded value is truncated to 3 decimal places