### PR TITLE
Negative accounting bug

### DIFF
--- a/backend/grant/admin/views.py
+++ b/backend/grant/admin/views.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_DOWN
 from functools import reduce
 
 from flask import Blueprint, request
@@ -773,7 +773,7 @@ def financials():
     }
 
     def add_str_dec(a: str, b: str):
-        return str(Decimal(a) + Decimal(b))
+        return str((Decimal(a) + Decimal(b)).quantize(Decimal('0.001'), rounding=ROUND_HALF_DOWN))
 
     proposals = Proposal.query.all()
 
@@ -782,13 +782,13 @@ def financials():
         if p.stage in [ProposalStage.WIP, ProposalStage.COMPLETED]:
             # matching
             matching = Decimal(p.contributed) * Decimal(p.contribution_matching)
-            remaining = Decimal(p.target) - Decimal(p.contributed)
+            remaining = max(Decimal(p.target) - Decimal(p.contributed), Decimal('0.0'))
             if matching > remaining:
                 matching = remaining
 
             # bounty
             bounty = Decimal(p.contribution_bounty)
-            remaining = Decimal(p.target) - (matching + Decimal(p.contributed))
+            remaining = max(Decimal(p.target) - (matching + Decimal(p.contributed)), Decimal('0.0'))
             if bounty > remaining:
                 bounty = remaining
 


### PR DESCRIPTION
Closes #426.

### What this does
- makes sure the grant bounties & matching numbers are never negative, which was happening when a proposal had contributions exceeding matching and/or bounty amounts

### Testing
- activate an RFP with matching and bounty
- create and stake a proposal for the RFP
- make a contribution to the proposal and overfund it via admin to an amount greater than matching & bounty
- proposal should be fully funded
- go to admin > financials and verify the grants bounty & matching numbers are not negative 

### Screen
<img width="354" alt="Screen Shot 2019-04-16 at 3 58 42 PM" src="https://user-images.githubusercontent.com/11430954/56243584-92f27180-6060-11e9-9444-4670a62ba0b3.png">
