### PR TITLE
Update Accepted Without Funding

### DIFF
--- a/admin/src/components/ProposalDetail/index.tsx
+++ b/admin/src/components/ProposalDetail/index.tsx
@@ -36,6 +36,7 @@ type Props = RouteComponentProps<any>;
 const STATE = {
   paidTxId: '',
   showCancelAndRefundPopover: false,
+  showChangeToAcceptedWithFundingPopover: false,
 };
 
 type State = typeof STATE;
@@ -63,11 +64,12 @@ class ProposalDetailNaked extends React.Component<Props, State> {
       return m.datePaid ? prev - parseFloat(m.payoutPercent) : prev;
     }, 100);
 
-    const { isVersionTwo } = p
+    const { isVersionTwo } = p;
     const shouldShowArbiter =
-      !isVersionTwo ||
-      (isVersionTwo && p.acceptedWithFunding === true);
-    const cancelButtonText = isVersionTwo ? 'Cancel' : 'Cancel & refund'
+      !isVersionTwo || (isVersionTwo && p.acceptedWithFunding === true);
+    const cancelButtonText = isVersionTwo ? 'Cancel' : 'Cancel & refund';
+    const shouldShowChangeToAcceptedWithFunding =
+      isVersionTwo && p.acceptedWithFunding === false;
 
     const renderCancelControl = () => {
       const disabled = this.getCancelAndRefundDisabled();
@@ -99,7 +101,40 @@ class ProposalDetailNaked extends React.Component<Props, State> {
             disabled={disabled}
             block
           >
-            { cancelButtonText }
+            {cancelButtonText}
+          </Button>
+        </Popconfirm>
+      );
+    };
+
+    const renderChangeToAcceptedWithFundingControl = () => {
+      return (
+        <Popconfirm
+          title={
+            <p>
+              Are you sure you want to accept the proposal
+              <br />
+              with funding? This cannot be undone.
+            </p>
+          }
+          placement="left"
+          cancelText="cancel"
+          okText="confirm"
+          visible={this.state.showChangeToAcceptedWithFundingPopover}
+          okButtonProps={{
+            loading: store.proposalDetailCanceling,
+          }}
+          onCancel={this.handleChangeToAcceptWithFundingCancel}
+          onConfirm={this.handleChangeToAcceptWithFundingConfirm}
+        >
+          <Button
+            icon="close-circle"
+            className="ProposalDetail-controls-control"
+            loading={store.proposalDetailChangingToAcceptedWithFunding}
+            onClick={this.handleChangeToAcceptedWithFunding}
+            block
+          >
+            Accept With Funding
           </Button>
         </Popconfirm>
       );
@@ -119,7 +154,6 @@ class ProposalDetailNaked extends React.Component<Props, State> {
         }}
       />
     );
-
 
     const renderApproved = () =>
       p.status === PROPOSAL_STATUS.APPROVED && (
@@ -200,7 +234,8 @@ class ProposalDetailNaked extends React.Component<Props, State> {
       );
 
     const renderNominateArbiter = () =>
-      needsArbiter && shouldShowArbiter && (
+      needsArbiter &&
+      shouldShowArbiter && (
         <Alert
           showIcon
           type="warning"
@@ -373,6 +408,8 @@ class ProposalDetailNaked extends React.Component<Props, State> {
             <Card size="small" className="ProposalDetail-controls">
               {renderCancelControl()}
               {renderArbiterControl()}
+              {shouldShowChangeToAcceptedWithFunding &&
+                renderChangeToAcceptedWithFundingControl()}
             </Card>
 
             {/* DETAILS */}
@@ -402,7 +439,10 @@ class ProposalDetailNaked extends React.Component<Props, State> {
               {renderDeetItem('matching', p.contributionMatching)}
               {renderDeetItem('bounty', p.contributionBounty)}
               {renderDeetItem('rfpOptIn', JSON.stringify(p.rfpOptIn))}
-              {renderDeetItem('acceptedWithFunding', JSON.stringify(p.acceptedWithFunding))}
+              {renderDeetItem(
+                'acceptedWithFunding',
+                JSON.stringify(p.acceptedWithFunding),
+              )}
               {renderDeetItem(
                 'arbiter',
                 <>
@@ -455,6 +495,20 @@ class ProposalDetailNaked extends React.Component<Props, State> {
         this.setState({ showCancelAndRefundPopover: true });
       }
     }
+  };
+
+  private handleChangeToAcceptedWithFunding = () => {
+    this.setState({ showChangeToAcceptedWithFundingPopover: true });
+  };
+
+  private handleChangeToAcceptWithFundingCancel = () => {
+    this.setState({ showChangeToAcceptedWithFundingPopover: false });
+  };
+
+  private handleChangeToAcceptWithFundingConfirm = () => {
+    if (!store.proposalDetail) return;
+    store.changeProposalToAcceptedWithFunding(store.proposalDetail.proposalId);
+    this.setState({ showChangeToAcceptedWithFundingPopover: false });
   };
 
   private getIdFromQuery = () => {

--- a/admin/src/store.ts
+++ b/admin/src/store.ts
@@ -148,6 +148,11 @@ async function cancelProposal(id: number) {
   return data;
 }
 
+async function changeProposalToAcceptedWithFunding(id: number) {
+  const { data } = await api.put(`/admin/proposals/${id}/accept/fund`)
+  return data
+}
+
 async function fetchComments(params: Partial<PageQuery>) {
   const { data } = await api.get('/admin/comments', { params });
   return data;
@@ -288,6 +293,7 @@ const app = store({
   proposalDetailCanceling: false,
   proposalDetailUpdating: false,
   proposalDetailUpdated: false,
+  proposalDetailChangingToAcceptedWithFunding: false,
 
   comments: {
     page: createDefaultPageData<Comment>('CREATED:DESC'),
@@ -569,6 +575,19 @@ const app = store({
       handleApiError(e);
     }
     app.proposalDetailCanceling = false;
+  },
+
+  async changeProposalToAcceptedWithFunding(id: number) {
+    app.proposalDetailChangingToAcceptedWithFunding = true
+
+    try {
+      const res = await changeProposalToAcceptedWithFunding(id)
+      app.updateProposalInStore(res)
+    } catch (e) {
+      handleApiError(e)
+    }
+
+    app.proposalDetailChangingToAcceptedWithFunding = false
   },
 
   async markMilestonePaid(proposalId: number, milestoneId: number, txId: string) {

--- a/backend/grant/admin/views.py
+++ b/backend/grant/admin/views.py
@@ -369,6 +369,26 @@ def approve_proposal(id, is_accepted, with_funding, reject_reason=None):
     return {"message": "No proposal found."}, 404
 
 
+@blueprint.route('/proposals/<id>/accept/fund', methods=['PUT'])
+@admin.admin_auth_required
+def change_proposal_to_accepted_with_funding(id):
+    proposal = Proposal.query.filter_by(id=id).first()
+    if not proposal:
+        return {"message": "No proposal found."}, 404
+    if proposal.accepted_with_funding:
+        return {"message": "Proposal already accepted with funding."}, 404
+    if proposal.version != '2':
+        return {"message": "Only version two proposals can be accepted with funding"}, 404
+    if proposal.status != ProposalStatus.LIVE and proposal.status != ProposalStatus.APPROVED:
+        return {"message": "Only live or approved proposals can be modified by this endpoint"}, 404
+
+    proposal.update_proposal_with_funding()
+    db.session.add(proposal)
+    db.session.commit()
+
+    return proposal_schema.dump(proposal)
+
+
 @blueprint.route('/proposals/<id>/cancel', methods=['PUT'])
 @admin.admin_auth_required
 def cancel_proposal(id):

--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -529,6 +529,10 @@ class Proposal(db.Model):
                     'admin_note': reject_reason
                 })
 
+    def update_proposal_with_funding(self):
+        self.accepted_with_funding = True
+        self.fully_fund_contibution_bounty()
+
     # state: status APPROVE -> LIVE, stage PREVIEW -> FUNDING_REQUIRED
     def publish(self):
         self.validate_publishable()

--- a/backend/tests/admin/test_admin_api.py
+++ b/backend/tests/admin/test_admin_api.py
@@ -278,6 +278,54 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         self.assertEqual(resp.json["acceptedWithFunding"], False)
         self.assertEqual(resp.json["contributionBounty"], "0")
 
+    def test_change_proposal_to_accepted_with_funding(self):
+        self.login_admin()
+
+        # proposal needs to be PENDING
+        self.proposal.status = ProposalStatus.PENDING
+
+        # accept without funding
+        resp = self.app.put(
+            "/api/v1/admin/proposals/{}/accept".format(self.proposal.id),
+            data=json.dumps({"isAccepted": True, "withFunding": False})
+        )
+        self.assert200(resp)
+        self.assertEqual(resp.json["acceptedWithFunding"], False)
+
+        # change to accepted with funding
+        resp = self.app.put(
+            f"/api/v1/admin/proposals/{self.proposal.id}/accept/fund"
+        )
+        self.assert200(resp)
+        self.assertEqual(resp.json["acceptedWithFunding"], True)
+
+        # should fail if proposal is already accepted with funding
+        resp = self.app.put(
+            f"/api/v1/admin/proposals/{self.proposal.id}/accept/fund"
+        )
+        self.assert404(resp)
+        self.assertEqual(resp.json['message'], "Proposal already accepted with funding.")
+        self.proposal.accepted_with_funding = False
+
+        # should fail if proposal is not version two
+        self.proposal.version = ''
+        resp = self.app.put(
+            f"/api/v1/admin/proposals/{self.proposal.id}/accept/fund"
+        )
+        self.assert404(resp)
+        self.assertEqual(resp.json['message'], "Only version two proposals can be accepted with funding")
+        self.proposal.version = '2'
+
+        # should failed if proposal is not LIVE or APPROVED
+        self.proposal.status = ProposalStatus.PENDING
+        self.proposal.accepted_with_funding = False
+        resp = self.app.put(
+            f"/api/v1/admin/proposals/{self.proposal.id}/accept/fund"
+        )
+        self.assert404(resp)
+        self.assertEqual(resp.json["message"], 'Only live or approved proposals can be modified by this endpoint')
+
+
 
     @patch('requests.get', side_effect=mock_blockchain_api_requests)
     def test_reject_proposal(self, mock_get):

--- a/backend/tests/admin/test_admin_api.py
+++ b/backend/tests/admin/test_admin_api.py
@@ -278,7 +278,8 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         self.assertEqual(resp.json["acceptedWithFunding"], False)
         self.assertEqual(resp.json["contributionBounty"], "0")
 
-    def test_change_proposal_to_accepted_with_funding(self):
+    @patch('requests.get', side_effect=mock_blockchain_api_requests)
+    def test_change_proposal_to_accepted_with_funding(self, mock_get):
         self.login_admin()
 
         # proposal needs to be PENDING


### PR DESCRIPTION
Allows admins to accept a proposal with funding that was previously accepted without funding. This is a one-way change as there's no functionality to remove funding from a proposal. Closes #26. 

Adds an `Accept With Funding` button under arbiter control in the proposal detail view that's only displayed if (1) the proposal is version two and (2) the proposal has been accepted without funding. 

-----------
Also, looks like Prettier added some noise on a couple files. Perhaps the normal pre-commit hook isn't working correctly?