### PR TITLE
Display Milestones Placeholder for Proposals Accepted Without Funding

### DIFF
--- a/frontend/client/components/Proposal/Milestones/index.tsx
+++ b/frontend/client/components/Proposal/Milestones/index.tsx
@@ -156,8 +156,15 @@ class ProposalMilestones extends React.Component<Props, State> {
     if (!proposal) {
       return <Loader />;
     }
-    const { milestones, currentMilestone, isRejectingPayout } = proposal;
+    const {
+      milestones,
+      currentMilestone,
+      isRejectingPayout,
+      isVersionTwo,
+      acceptedWithFunding,
+    } = proposal;
     const milestoneCount = milestones.length;
+    const milestonesDisabled = isVersionTwo ? !acceptedWithFunding : false;
 
     // arbiter reject modal
     const rejectModal = (
@@ -220,7 +227,12 @@ class ProposalMilestones extends React.Component<Props, State> {
           ['do-titles-overflow']: this.state.doTitlesOverflow,
         })}
       >
-        {!!milestoneSteps.length ? (
+        {milestonesDisabled ? (
+          <Placeholder
+            title="Milestones unavailable"
+            subtitle="Milestones are not tracked for proposals that have been accepted without funding"
+          />
+        ) : !!milestoneSteps.length ? (
           <>
             <Steps current={this.state.step} size={stepSize}>
               {milestoneSteps.map(mss => (

--- a/frontend/client/components/Proposal/index.tsx
+++ b/frontend/client/components/Proposal/index.tsx
@@ -101,6 +101,10 @@ export class ProposalDetail extends React.Component<Props, State> {
 
     const isTrustee = !!proposal.team.find(tm => tm.userid === (user && user.userid));
     const isLive = proposal.status === STATUS.LIVE;
+    const milestonesDisabled = proposal.isVersionTwo
+      ? !proposal.acceptedWithFunding
+      : false;
+    const defaultTab = milestonesDisabled ? 'discussions' : 'milestones';
 
     const adminMenu = (
       <Menu>
@@ -230,7 +234,7 @@ export class ProposalDetail extends React.Component<Props, State> {
         </div>
 
         <div className="Proposal-bottom">
-          <LinkableTabs scrollToTabs defaultActiveKey="milestones">
+          <LinkableTabs scrollToTabs defaultActiveKey={defaultTab}>
             <Tabs.TabPane tab="Milestones" key="milestones">
               <div style={{ marginTop: '1.5rem', padding: '0 2rem' }}>
                 <Milestones proposal={proposal} />


### PR DESCRIPTION
Closes #27.

Takes the disabling route described in #27 until we can get feedback. 

If a proposal both (1) is version two and (2) has been accepted without funding, two things happen in the proposal view:

 - A placeholder is displayed on the `milestones` tab
 - The default tab is `discussions` since `milestones` will always be a placeholder