### PR TITLE
Fix Like & Follow Proposal Margin

### DIFF
--- a/frontend/client/components/Follow/index.tsx
+++ b/frontend/client/components/Follow/index.tsx
@@ -10,6 +10,7 @@ import './index.less';
 
 interface OwnProps {
   proposal: ProposalDetail;
+  style?: React.CSSProperties;
 }
 
 interface StateProps {
@@ -30,10 +31,11 @@ type State = typeof STATE;
 class Follow extends React.Component<Props, State> {
   state: State = { ...STATE };
   render() {
+    const { style } = this.props;
     const { authedFollows, followersCount } = this.props.proposal;
     const { loading } = this.state;
     return (
-      <Input.Group className="Follow" compact>
+      <Input.Group style={style} className="Follow" compact>
         <AuthButton onClick={this.handleFollow}>
           <Icon
             theme={authedFollows ? 'filled' : 'outlined'}

--- a/frontend/client/components/Like/index.tsx
+++ b/frontend/client/components/Like/index.tsx
@@ -14,6 +14,7 @@ interface OwnProps {
   proposal?: ProposalDetail | null;
   comment?: Comment;
   rfp?: RFP;
+  style?: React.CSSProperties;
 }
 
 interface StateProps {
@@ -38,13 +39,13 @@ class Follow extends React.Component<Props, State> {
 
   render() {
     const { likesCount, authedLiked } = this.deriveInfo();
-    const { proposal, rfp, comment } = this.props;
+    const { proposal, rfp, comment, style } = this.props;
     const { loading } = this.state;
     const zoom = comment ? 0.8 : 1;
     const shouldShowLikeText = !!proposal || !!rfp;
 
     return (
-      <Input.Group className="Like" compact style={{ zoom }}>
+      <Input.Group className="Like" compact style={{ zoom, ...style }}>
         <AuthButton onClick={this.handleLike}>
           <Icon
             theme={authedLiked ? 'filled' : 'outlined'}

--- a/frontend/client/components/Proposal/index.less
+++ b/frontend/client/components/Proposal/index.less
@@ -103,10 +103,6 @@
           & .ant-input-group {
             width: inherit
           }
-
-          & > * + * {
-            margin-left: 0.5rem;
-          }
         }
       }
 

--- a/frontend/client/components/Proposal/index.tsx
+++ b/frontend/client/components/Proposal/index.tsx
@@ -206,8 +206,8 @@ export class ProposalDetail extends React.Component<Props, State> {
                       </Button>
                     </Dropdown>
                   )}
-                  <Like proposal={proposal} />
-                  <Follow proposal={proposal} />
+                  <Like proposal={proposal} style={{ marginLeft: '0.5rem' }} />
+                  <Follow proposal={proposal} style={{ marginLeft: '0.5rem' }} />
                 </div>
               )}
             </div>


### PR DESCRIPTION
This was an interesting bug to work out. Two stylesheets apply styling to these buttons: `index.less` (specific styling we've created) and `style.less` (generic styling that provides defaults for all Ant components). The margin gets dropped in production when `style.less` is applied _after_ `index.less` and overrides the custom styling. 

When starting off on the proposals page and clicking on a proposal, the styling is applied correctly. However, when loading the page from a proposal directly, the stylesheets are applied in a different order and the margin is overridden. Thus, this seems to be a SSR issue. 

Since this bug appears to be isolated to this particular style, the fix included in this PR simply applies the margin styling to the components directly via the `style` prop. 

Running the production build with `yarn start` doesn't work on my machine, so I'm unable to directly test this fix. Closes #45.
 
