### PR TITLE
Add Explainer to Proposal Creation Flow.

### DIFF
--- a/frontend/client/components/CreateFlow/Explainer.less
+++ b/frontend/client/components/CreateFlow/Explainer.less
@@ -1,0 +1,85 @@
+@import '~styles/variables.less';
+
+@small-query: ~'(max-width: 640px)';
+
+.Explainer {
+  display: flex;
+  flex-direction: column;
+
+  &-header {
+    margin: 3rem auto 5rem;
+
+    &-title {
+      font-size: 2rem;
+      text-align: center;
+
+    }
+
+    &-subtitle {
+      font-size: 1.4rem;
+      margin-bottom: 0;
+      opacity: 0.7;
+      text-align: center;
+
+      @media @small-query {
+        font-size: 1.8rem;
+      }
+    }
+  }
+
+  &-create {
+    display: block;
+    width: 280px;
+    margin-top: 0.5rem;
+    height: 3.2rem;
+  }
+
+  &-actions {
+    margin: 4rem auto;
+    justify-content: center;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &-items {
+    max-width: 1200px;
+    padding: 0 2rem;
+    margin: 0 auto;
+    display: flex;
+
+    @media @small-query {
+      flex-direction: column;
+    }
+
+    &-item {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin: 0 2rem;
+      flex-direction: column;
+
+      @media @small-query {
+        margin-bottom: 5rem;
+      }
+
+      &-text {
+        font-size: 1.1rem;
+        text-align: center;
+        margin-top: 1rem;
+
+        @media @small-query {
+          font-size: 1.5rem;
+        }
+      }
+
+      &-icon {
+        flex-shrink: 0;
+        width: 8rem;
+
+        @media @small-query {
+          width: 12rem;
+        }
+      }
+    }
+  }
+}

--- a/frontend/client/components/CreateFlow/Explainer.tsx
+++ b/frontend/client/components/CreateFlow/Explainer.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { withNamespaces, WithNamespaces } from 'react-i18next';
+import SubmitIcon from 'static/images/guide-submit.svg';
+import ReviewIcon from 'static/images/guide-review.svg';
+import CommunityIcon from 'static/images/guide-community.svg';
+import './Explainer.less';
+import * as ls from 'local-storage';
+import { Button, Checkbox, Icon } from 'antd';
+
+interface CreateProps {
+  startSteps: () => void;
+}
+
+type Props = WithNamespaces & CreateProps;
+
+const Explainer: React.SFC<Props> = ({ t, startSteps }) => {
+  const items = [
+    {
+      text: t('home.guide.submit'),
+      icon: <SubmitIcon />,
+    },
+    {
+      text: t('home.guide.review'),
+      icon: <ReviewIcon />,
+    },
+    {
+      text: t('home.guide.community'),
+      icon: <CommunityIcon />,
+    },
+  ];
+
+  return (
+    <div className="Explainer">
+      <div className="Explainer-header">
+        <h2 className="Explainer-header-title">{t('home.guide.title')}</h2>
+        <div className="Explainer-header-subtitle">
+          You're almost ready to create a proposal.
+        </div>
+      </div>
+      <div className="Explainer-items">
+        {items.map((item, idx) => (
+          <div className="Explainer-items-item" key={idx}>
+            <div className="Explainer-items-item-icon">{item.icon}</div>
+            <div className="Explainer-items-item-text">{item.text}</div>
+          </div>
+        ))}
+      </div>
+      <div className="Explainer-actions">
+        <Checkbox onChange={ev => ls.set<boolean>('noExplain', ev.target.checked)}>
+          Don't show this again
+        </Checkbox>
+        <Button
+          className="Explainer-create"
+          type="primary"
+          size="large"
+          block
+          onClick={() => startSteps()}
+        >
+          Let's do this <Icon type="right-circle-o" />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default withNamespaces()(Explainer);

--- a/frontend/client/components/CreateFlow/index.tsx
+++ b/frontend/client/components/CreateFlow/index.tsx
@@ -14,11 +14,13 @@ import Payment from './Payment';
 import Review from './Review';
 import Preview from './Preview';
 import Final from './Final';
+import Explainer from './Explainer';
 import SubmitWarningModal from './SubmitWarningModal';
 import createExampleProposal from './example';
 import { createActions } from 'modules/create';
 import { ProposalDraft } from 'types';
 import { getCreateErrors } from 'modules/create/utils';
+import ls from 'local-storage';
 
 import { AppState } from 'store/reducers';
 
@@ -49,6 +51,11 @@ interface StepInfo {
   help: React.ReactNode;
   component: any;
 }
+
+interface LSExplainer {
+  noExplain: boolean;
+}
+
 const STEP_INFO: { [key in CREATE_STEP]: StepInfo } = {
   [CREATE_STEP.BASICS]: {
     short: 'Basics',
@@ -117,6 +124,7 @@ interface State {
   isPreviewing: boolean;
   isShowingSubmitWarning: boolean;
   isSubmitting: boolean;
+  isExplaining: boolean;
   isExample: boolean;
 }
 
@@ -132,12 +140,15 @@ class CreateFlow extends React.Component<Props, State> {
       queryStep && CREATE_STEP[queryStep]
         ? (CREATE_STEP[queryStep] as CREATE_STEP)
         : CREATE_STEP.BASICS;
+    const noExplain = !!ls<LSExplainer>('noExplain');
+
     this.state = {
       step,
       isPreviewing: false,
       isSubmitting: false,
       isExample: false,
       isShowingSubmitWarning: false,
+      isExplaining: !noExplain,
     };
     this.debouncedUpdateForm = debounce(this.updateForm, 800);
     this.historyUnlisten = this.props.history.listen(this.handlePop);
@@ -151,7 +162,13 @@ class CreateFlow extends React.Component<Props, State> {
 
   render() {
     const { isSavingDraft, saveDraftError } = this.props;
-    const { step, isPreviewing, isSubmitting, isShowingSubmitWarning } = this.state;
+    const {
+      step,
+      isPreviewing,
+      isSubmitting,
+      isShowingSubmitWarning,
+      isExplaining,
+    } = this.state;
 
     const info = STEP_INFO[step];
     const currentIndex = STEP_ORDER.indexOf(step);
@@ -165,6 +182,9 @@ class CreateFlow extends React.Component<Props, State> {
       showFooter = false;
     } else if (isPreviewing) {
       content = <Preview />;
+    } else if (isExplaining) {
+      content = <Explainer startSteps={this.startSteps} />;
+      showFooter = false;
     } else {
       // Antd definitions are missing `onClick` for step, even though it works.
       const Step = Steps.Step as any;
@@ -262,6 +282,10 @@ class CreateFlow extends React.Component<Props, State> {
 
   private updateForm = (form: Partial<ProposalDraft>) => {
     this.props.updateForm(form);
+  };
+
+  private startSteps = () => {
+    this.setState({ step: CREATE_STEP.BASICS, isExplaining: false, showFooter: true });
   };
 
   private setStep = (step: CREATE_STEP, skipHistory?: boolean) => {

--- a/frontend/client/components/CreateFlow/index.tsx
+++ b/frontend/client/components/CreateFlow/index.tsx
@@ -285,7 +285,7 @@ class CreateFlow extends React.Component<Props, State> {
   };
 
   private startSteps = () => {
-    this.setState({ step: CREATE_STEP.BASICS, isExplaining: false, showFooter: true });
+    this.setState({ step: CREATE_STEP.BASICS, isExplaining: false });
   };
 
   private setStep = (step: CREATE_STEP, skipHistory?: boolean) => {

--- a/frontend/client/utils/localstorage.ts
+++ b/frontend/client/utils/localstorage.ts
@@ -1,0 +1,3 @@
+export interface LSExplainer {
+  noExplain: boolean;
+}

--- a/frontend/client/utils/localstorage.ts
+++ b/frontend/client/utils/localstorage.ts
@@ -1,3 +1,0 @@
-export interface LSExplainer {
-  noExplain: boolean;
-}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -117,6 +117,7 @@
     "less": "3.9.0",
     "less-loader": "^4.1.0",
     "lint-staged": "^7.2.2",
+    "local-storage": "^2.0.0",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",
     "lodash.defaultsdeep": "^4.6.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7326,6 +7326,11 @@ loader-utils@1.1.0, loader-utils@^1.0.2, loader-utils@^1.1.0:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
+local-storage@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/local-storage/-/local-storage-2.0.0.tgz#748b7d041b197f46f3ec7393640851c175b64db8"
+  integrity sha512-/0sRoeijw7yr/igbVVygDuq6dlYCmtsuTmmpnweVlVtl/s10pf5BCq8LWBxW/AMyFJ3MhMUuggMZiYlx6qr9tw==
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"


### PR DESCRIPTION
Closes  https://github.com/grant-project/zcash-grant-system/issues/9

### What could be improved?
Since this is the first time LS has been used in the app (shocking!), and I don't envision additional usage of LS, I've taken the naive/simplistic approach of accessing and modifying LS state directly in the component. This is an anti-pattern and a saga/redux pattern should be used if LS were to be used again, but for this one-off, I feel comfortable with this minimal approach.

![2019-11-01 14 26 01](https://user-images.githubusercontent.com/7861465/68050680-ac34d580-fcb3-11e9-951f-5f2910fcc9d9.gif)

### Steps to test:
1. Create a new proposal
2. Notice new proposal explainer
3. Create a new proposal
4. Check "Don't show me again"
5. See that the explainer no longer appears.
