### PR TITLE
Open for Public Review - Part 3

### DIFF
--- a/admin/src/components/Emails/emails.ts
+++ b/admin/src/components/Emails/emails.ts
@@ -42,9 +42,19 @@ export default [
     description: 'Sent when an admin approves your submitted proposal',
   },
   {
+    id: 'proposal_approved_discussion',
+    title: 'Proposal approved for public discussion',
+    description: 'Sent when an admin approves a proposal for public discussion',
+  },
+  {
     id: 'proposal_rejected',
     title: 'Proposal changes requested',
     description: 'Sent when an admin requests changes for your submitted proposal',
+  },
+    {
+    id: 'proposal_rejected_discussion',
+    title: 'Proposal changes requested',
+    description: 'Sent when an admin requests changes for a proposal open for public discussion',
   },
   {
     id: 'proposal_contribution',
@@ -139,6 +149,11 @@ export default [
     id: 'admin_approval',
     title: 'Admin Approval',
     description: 'Sent when proposal is ready for review',
+  },
+  {
+    id: 'admin_changes_resolved',
+    title: 'Admin Requested Changes Resolved',
+    description: 'Sent when proposal team has marked requested changes as resolved',
   },
   {
     id: 'admin_arbiter',

--- a/admin/src/components/Emails/emails.ts
+++ b/admin/src/components/Emails/emails.ts
@@ -51,10 +51,11 @@ export default [
     title: 'Proposal changes requested',
     description: 'Sent when an admin requests changes for your submitted proposal',
   },
-    {
+  {
     id: 'proposal_rejected_discussion',
     title: 'Proposal changes requested',
-    description: 'Sent when an admin requests changes for a proposal open for public discussion',
+    description:
+      'Sent when an admin requests changes for a proposal open for public discussion',
   },
   {
     id: 'proposal_contribution',
@@ -175,5 +176,10 @@ export default [
     id: 'followed_proposal_update',
     title: 'Followed Proposal Update',
     description: 'Sent to followers of a proposal when it has a new update',
+  },
+  {
+    id: 'followed_proposal_revised',
+    title: 'Followed Proposal Revised',
+    description: 'Sent to followers of a proposal when a revision has been made',
   },
 ] as Email[];

--- a/backend/grant/admin/example_emails.py
+++ b/backend/grant/admin/example_emails.py
@@ -203,4 +203,8 @@ example_email_args = {
         "proposal": proposal,
         "proposal_url": "http://someproposal.com",
     },
+    'followed_proposal_revised': {
+        "proposal": proposal,
+        "proposal_url": "http://someproposal.com",
+    },
 }

--- a/backend/grant/admin/example_emails.py
+++ b/backend/grant/admin/example_emails.py
@@ -72,10 +72,18 @@ example_email_args = {
         'proposal_url': 'http://someproposal.com',
         'admin_note': 'This proposal was the hottest stuff our team has seen yet. We look forward to throwing the fat stacks at you.',
     },
+    'proposal_approved_discussion': {
+        'proposal': proposal,
+        'proposal_url': 'http://someproposal.com',
+    },
     'proposal_rejected': {
         'proposal': proposal,
         'proposal_url': 'http://someproposal.com',
         'admin_note': 'We think that you’ve asked for too much money for the project you’ve proposed, and for such an inexperienced team. Feel free to change your target amount, or elaborate on why you need so much money, and try applying again.',
+    },
+    'proposal_rejected_discussion': {
+        'proposal': proposal,
+        'proposal_url': 'http://someproposal.com',
     },
     'proposal_contribution': {
         'proposal': proposal,
@@ -171,6 +179,10 @@ example_email_args = {
         'proposal_milestones_url': 'http://zfnd.org/proposals/999-my-proposal?tab=milestones',
     },
     'admin_approval': {
+        'proposal': proposal,
+        'proposal_url': 'https://grants-admin.zfnd.org/proposals/999',
+    },
+    'admin_changes_resolved': {
         'proposal': proposal,
         'proposal_url': 'https://grants-admin.zfnd.org/proposals/999',
     },

--- a/backend/grant/admin/views.py
+++ b/backend/grant/admin/views.py
@@ -358,14 +358,14 @@ def delete_proposal(id):
     return {"message": "Not implemented."}, 400
 
 
-@blueprint.route('/proposals/<id>/discussion', methods=['PUT'])
+@blueprint.route('/proposals/<proposal_id>/discussion', methods=['PUT'])
 @body({
     "isOpenForDiscussion": fields.Bool(required=True),
     "rejectReason": fields.Str(required=False, missing=None)
 })
 @admin.admin_auth_required
-def open_proposal_for_discussion(id, is_open_for_discussion, reject_reason=None):
-    proposal = Proposal.query.get(id)
+def open_proposal_for_discussion(proposal_id, is_open_for_discussion, reject_reason=None):
+    proposal = Proposal.query.get(proposal_id)
     if not proposal:
         return {"message": "No Proposal found."}, 404
 
@@ -399,10 +399,10 @@ def accept_proposal(id, is_accepted, with_funding, changes_requested_reason):
     return proposal_schema.dump(proposal)
 
 
-@blueprint.route('/proposals/<id>/resolve', methods=['PUT'])
+@blueprint.route('/proposals/<proposal_id>/resolve', methods=['PUT'])
 @admin.admin_auth_required
-def resolve_changes_discussion(id):
-    proposal = Proposal.query.get(id)
+def resolve_changes_discussion(proposal_id):
+    proposal = Proposal.query.get(proposal_id)
     if not proposal:
         return {"message": "No proposal found"}, 404
 

--- a/backend/grant/email/send.py
+++ b/backend/grant/email/send.py
@@ -392,6 +392,16 @@ def followed_proposal_update(email_args):
     }
 
 
+def followed_proposal_revised(email_args):
+    p = email_args["proposal"]
+    return {
+        "subject": f"Proposal has been revised for {p.title}",
+        "title": f"Proposal Revised",
+        "preview": f"Followed proposal {p.title} has been revised",
+        "subscription": EmailSubscription.FOLLOWED_PROPOSAL,
+    }
+
+
 get_info_lookup = {
     'signup': signup_info,
     'team_invite': team_invite_info,
@@ -429,7 +439,8 @@ get_info_lookup = {
     'admin_arbiter': admin_arbiter,
     'admin_payout': admin_payout,
     'followed_proposal_milestone': followed_proposal_milestone,
-    'followed_proposal_update': followed_proposal_update
+    'followed_proposal_update': followed_proposal_update,
+    'followed_proposal_revised': followed_proposal_revised
 }
 
 

--- a/backend/grant/email/send.py
+++ b/backend/grant/email/send.py
@@ -76,6 +76,15 @@ def proposal_approved(email_args):
     }
 
 
+def proposal_approved_discussion(email_args):
+    return {
+        'subject': 'Your proposal has been opened for discussion',
+        'title': 'Your proposal has been opened for discussion',
+        'preview': '{} is now open for public discussion on ZF Grants.'.format(email_args['proposal'].title),
+        'subscription': EmailSubscription.MY_PROPOSAL_APPROVAL
+    }
+
+
 def ccr_approved(email_args):
     return {
         'subject': 'Your request has been approved!',
@@ -93,6 +102,15 @@ def ccr_rejected(email_args):
 
 
 def proposal_rejected(email_args):
+    return {
+        'subject': 'Your proposal has changes requested',
+        'title': 'Your proposal has changes requested',
+        'preview': '{} has changes requested'.format(email_args['proposal'].title),
+        'subscription': EmailSubscription.MY_PROPOSAL_APPROVAL
+    }
+
+
+def proposal_rejected_discussion(email_args):
     return {
         'subject': 'Your proposal has changes requested',
         'title': 'Your proposal has changes requested',
@@ -326,6 +344,15 @@ def admin_approval_ccr(email_args):
     }
 
 
+def admin_changes_resolved(email_args):
+    return {
+        'subject': f'Changes marked as resolved for {email_args["proposal"].title}',
+        'title': f'Changes Resolved',
+        'preview': f'Team members of proposal {email_args["proposal"].title} have marked requested changes as resolved.',
+        'subscription': EmailSubscription.ADMIN_APPROVAL,
+    }
+
+
 def admin_arbiter(email_args):
     return {
         'subject': f'Arbiter needed for {email_args["proposal"].title}',
@@ -375,7 +402,9 @@ get_info_lookup = {
     'ccr_rejected': ccr_rejected,
     'ccr_approved': ccr_approved,
     'proposal_approved': proposal_approved,
+    'proposal_approved_discussion': proposal_approved_discussion,
     'proposal_rejected': proposal_rejected,
+    'proposal_rejected_discussion': proposal_rejected_discussion,
     'proposal_contribution': proposal_contribution,
     'proposal_comment': proposal_comment,
     'proposal_failed': proposal_failed,
@@ -396,6 +425,7 @@ get_info_lookup = {
     'milestone_paid': milestone_paid,
     'admin_approval': admin_approval,
     'admin_approval_ccr': admin_approval_ccr,
+    'admin_changes_resolved': admin_changes_resolved,
     'admin_arbiter': admin_arbiter,
     'admin_payout': admin_payout,
     'followed_proposal_milestone': followed_proposal_milestone,

--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -591,6 +591,12 @@ class Proposal(db.Model):
 
         if is_open_for_discussion:
             self.status = ProposalStatus.DISCUSSION
+            for t in self.team:
+                send_email(t.email_address, 'proposal_approved_discussion', {
+                    'user': t,
+                    'proposal': self,
+                    'proposal_url': make_url(f'/proposals/{self.id}')
+                })
         else:
             if not reject_reason:
                 raise ValidationException("Please provide a reason for rejecting the proposal")
@@ -613,6 +619,13 @@ class Proposal(db.Model):
 
         self.changes_requested_discussion = True
         self.changes_requested_discussion_reason = reason
+        for t in self.team:
+            send_email(t.email_address, 'proposal_rejected_discussion', {
+                'user': t,
+                'proposal': self,
+                'proposal_url': make_url(f'/proposals/{self.id}'),
+                'admin_note': reason
+            })
 
     # mark a request changes as resolve for a proposal with a DISCUSSION status
     def resolve_changes_discussion(self):

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -399,6 +399,11 @@ def publish_live_draft(proposal_id):
     parent_proposal.consume_live_draft()
     db.session.commit()
 
+    # Send email to all followers
+    parent_proposal.send_follower_email(
+        "followed_proposal_revised", url_suffix="?tab=revisions"
+    )
+
     return proposal_schema.dump(parent_proposal), 200
 
 

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -374,6 +374,12 @@ def publish_proposal(proposal_id):
 @blueprint.route("/<proposal_id>/publish/live", methods=["PUT"])
 @requires_team_member_auth
 def publish_live_draft(proposal_id):
+    if g.current_proposal.status != ProposalStatus.LIVE_DRAFT:
+        return {"message": "Proposal is not a live draft"}, 403
+
+    if not g.current_proposal.live_draft_parent_id:
+        return {"message": "No parent proposal found"}, 404
+
     parent_proposal = Proposal.query.get(g.current_proposal.live_draft_parent_id)
 
     if not parent_proposal:

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -287,9 +287,10 @@ def resolve_changes_discussion(proposal_id):
         return {"message": "No proposal found"}, 404
 
     proposal.resolve_changes_discussion()
-
     db.session.add(proposal)
     db.session.commit()
+
+    proposal.send_admin_email('admin_changes_resolved')
     return proposal_schema.dump(proposal)
 
 

--- a/backend/grant/templates/emails/admin_changes_resolved.html
+++ b/backend/grant/templates/emails/admin_changes_resolved.html
@@ -1,0 +1,33 @@
+<p style="margin: 0 0 20px;">
+    Team members of proposal
+  <a href="{{ args.proposal_url }}" target="_blank">
+    {{ args.proposal.title }}</a
+  >
+  have marked requested changes as resolved. As an admin you can help out by reviewing it.
+</p>
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td bgcolor="#ffffff" align="center" style="padding: 40px 30px 40px 30px;">
+      <table border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td
+            align="center"
+            style="border-radius: 3px;"
+            bgcolor="{{ UI.PRIMARY }}"
+          >
+            <a
+              href="{{ args.proposal_url }}"
+              target="_blank"
+              style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{
+                UI.PRIMARY
+              }}; display: inline-block;"
+            >
+              Review Proposal
+            </a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/backend/grant/templates/emails/admin_changes_resolved.txt
+++ b/backend/grant/templates/emails/admin_changes_resolved.txt
@@ -1,0 +1,5 @@
+Team members of proposal {{ args.proposal.title }} have marked requested changes as resolved.
+
+As an admin you can help out by reviewing it.
+
+Visit the proposal and review: {{ args.proposal_url }}

--- a/backend/grant/templates/emails/followed_proposal_revised.html
+++ b/backend/grant/templates/emails/followed_proposal_revised.html
@@ -1,0 +1,29 @@
+<p style="margin: 0;">
+    Your followed proposal {{ args.proposal.title }} has been revised!
+</p>
+
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tr>
+        <td align="center" bgcolor="#ffffff" style="padding: 40px 30px 40px 30px;">
+            <table border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td
+                            align="center"
+                            bgcolor="{{ UI.PRIMARY }}"
+                            style="border-radius: 3px;"
+                    >
+                        <a
+                                href="{{ args.proposal_url }}"
+                                style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 20px 50px; border-radius: 4px; border: 1px solid {{
+                UI.PRIMARY
+              }}; display: inline-block;"
+                                target="_blank"
+                        >
+                            Check it out
+                        </a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>

--- a/backend/grant/templates/emails/followed_proposal_revised.txt
+++ b/backend/grant/templates/emails/followed_proposal_revised.txt
@@ -1,0 +1,3 @@
+Your followed proposal {{ args.proposal.title }} has been revised!
+
+Check it out: {{ args.proposal_url }}

--- a/backend/grant/templates/emails/proposal_approved_discussion.html
+++ b/backend/grant/templates/emails/proposal_approved_discussion.html
@@ -1,0 +1,13 @@
+<p style="margin: 0;">
+    Your proposal has been reviewed by the Zcash Foundation and is now open for public discussion on ZF Grants!
+</p>
+
+{% if args.admin_note %}
+<p style="margin: 20px 0 0;">
+    A note from the admin team was attached to your approval:
+</p>
+<p style="margin: 10px 0; padding: 20px; background: #F8F8F8;">
+    “{{ args.admin_note }}”
+</p>
+{% endif %}
+

--- a/backend/grant/templates/emails/proposal_approved_discussion.txt
+++ b/backend/grant/templates/emails/proposal_approved_discussion.txt
@@ -1,0 +1,10 @@
+Your proposal has been reviewed by the Zcash Foundation and is now open for public discussion on ZF Grants!
+
+
+{% if args.admin_note %}
+A note from the admin team was attached to your approval:
+
+> {{ args.admin_note }}
+{% endif %}
+
+{{ args.proposal_url }}

--- a/backend/grant/templates/emails/proposal_rejected_discussion.html
+++ b/backend/grant/templates/emails/proposal_rejected_discussion.html
@@ -1,0 +1,19 @@
+<p style="margin: 0;">
+    Your proposal is still open for public discussion, but an admin has requested changes.
+    Please make the necessary edits and mark the changes as resolved.
+</p>
+
+{% if args.admin_note %}
+<p style="margin: 20px 0 0;">
+    A note from the admin team was attached to this request:
+</p>
+<p style="margin: 10px 0; padding: 20px; background: #F8F8F8;">
+    “{{ args.admin_note }}”
+</p>
+{% endif %}
+
+<p style="margin: 20px 0 0; font-size: 12px; line-height: 18px; color: #999; text-align: center;">
+    Please note that repeated submissions without significant changes or with
+    content that doesn't match the platform guidelines may result in a removal
+    of your submission privileges.
+</p>

--- a/backend/grant/templates/emails/proposal_rejected_discussion.txt
+++ b/backend/grant/templates/emails/proposal_rejected_discussion.txt
@@ -1,0 +1,12 @@
+    Your proposal is still open for public discussion, but an admin has requested changes.
+    Please make the necessary edits and mark the changes as resolved.
+
+{% if args.admin_note %}
+A note from the admin team was attached to this request:
+
+> {{ args.admin_note }}
+{% endif %}
+
+Please note that repeated submissions without significant changes or with
+content that doesn't match the platform guidelines may result in a removal
+of your submission privileges.

--- a/backend/tests/proposal/test_api.py
+++ b/backend/tests/proposal/test_api.py
@@ -281,3 +281,181 @@ class TestProposalAPI(BaseProposalCreatorConfig):
         self.assert200(resp)
         self.assertEqual(resp.json["authedLiked"], False)
         self.assertEqual(resp.json["likesCount"], 0)
+
+    def test_resolve_changes_discussion(self):
+        self.login_default_user()
+
+        self.proposal.status = ProposalStatus.DISCUSSION
+        self.proposal.changes_requested_discussion = True
+        self.proposal.changes_requested_discussion_reason = 'test'
+
+        resp = self.app.put(
+            f"/api/v1/proposals/{self.proposal.id}/resolve"
+        )
+        self.assert200(resp)
+        self.assertEqual(resp.json['changesRequestedDiscussion'], False)
+        self.assertIsNone(resp.json['changesRequestedDiscussionReason'])
+
+        proposal = Proposal.query.get(self.proposal.id)
+        self.assertEqual(proposal.changes_requested_discussion, False)
+        self.assertIsNone(proposal.changes_requested_discussion_reason)
+
+    def test_resolve_changes_discussion_wrong_status_fail(self):
+        # resolve should fail if proposal is not in a DISCUSSION state
+        self.login_default_user()
+        self.proposal.status = ProposalStatus.PENDING
+        self.proposal.changes_requested_discussion = True
+        self.proposal.changes_requested_discussion_reason = 'test'
+
+        # resolve changes
+        resp = self.app.put(
+            f"/api/v1/proposals/{self.proposal.id}/resolve"
+        )
+        self.assert400(resp)
+
+    def test_resolve_changes_discussion_bad_proposal_fail(self):
+        # resolve should fail if bad proposal id is provided
+        self.login_default_user()
+        bad_id = '111111111111'
+        # resolve changes
+        resp = self.app.put(
+            f"/api/v1/proposals/{bad_id}/resolve"
+        )
+        self.assert404(resp)
+
+    def test_resolve_changes_discussion_no_changes_requested_fail(self):
+        # resolve should fail if changes are not requested on the proposal
+        self.login_default_user()
+        self.proposal.status = ProposalStatus.DISCUSSION
+        self.proposal.changes_requested_discussion = False
+        self.proposal.changes_requested_discussion_reason = None
+
+        # resolve changes
+        resp = self.app.put(
+            f"/api/v1/proposals/{self.proposal.id}/resolve"
+        )
+        self.assert400(resp)
+
+    def test_make_proposal_live_draft(self):
+        # user should be able to make live draft of a proposal
+        self.login_default_user()
+        self.proposal.status = ProposalStatus.DISCUSSION
+
+        draft_resp = self.app.post(
+            f"/api/v1/proposals/{self.proposal.id}/draft"
+        )
+        self.assertStatus(draft_resp, 201)
+        self.assertIsNone(draft_resp.json['liveDraftId'])
+        self.assertEqual(draft_resp.json['status'], ProposalStatus.LIVE_DRAFT)
+
+        proposal = Proposal.query.get(self.proposal.id)
+        draft = Proposal.query.get(draft_resp.json['proposalId'])
+        draft_id = draft.id
+
+        self.assertEqual(draft.live_draft_parent_id, proposal.id)
+        self.assertEqual(proposal.live_draft, draft)
+
+        # live draft id should be included in the parent proposal json response
+        proposal_resp = self.app.get(
+            f"/api/v1/proposals/{self.proposal.id}"
+        )
+        self.assert200(proposal_resp)
+        self.assertEqual(proposal_resp.json['liveDraftId'], draft_id)
+
+        # if endpoint is called again, the same live draft should be returned
+        resp = self.app.post(
+            f"/api/v1/proposals/{self.proposal.id}/draft"
+        )
+        self.assertStatus(resp, 201)
+        self.assertEqual(resp.json['status'], ProposalStatus.LIVE_DRAFT)
+        self.assertEqual(resp.json['proposalId'], draft_id)
+
+        # check milestones were copied
+
+        for i, ms in enumerate(draft_resp.json['milestones']):
+            title_draft = ms['title']
+            title_proposal = proposal_resp.json['milestones'][i]['title']
+
+            self.assertEqual(title_draft, title_proposal)
+
+    def test_make_proposal_live_draft_bad_status_fail(self):
+        # making live draft should fail if not in a DISCUSSION status
+        self.login_default_user()
+        resp = self.app.post(
+            f"/api/v1/proposals/{self.proposal.id}/draft"
+        )
+        self.assert404(resp)
+
+    @patch('requests.get', side_effect=mock_blockchain_api_requests)
+    def test_publish_live_draft(self, mock_get):
+        # user should be able to publish live draft of a proposal
+        self.login_default_user()
+        self.proposal.status = ProposalStatus.DISCUSSION
+
+        # create live draft
+        draft_resp = self.app.post(
+            f"/api/v1/proposals/{self.proposal.id}/draft"
+        )
+
+        # check the two proposals have been related correctly
+        self.assertStatus(draft_resp, 201)
+        self.assertNotEqual(draft_resp.json['proposalId'], self.proposal.id)
+        draft = Proposal.query.get(draft_resp.json['proposalId'])
+        draft_id = draft.id
+
+        # update live draft title
+        new_draft_title = 'This is a test for live drafts!'
+        draft.title = new_draft_title
+
+        # update live draft first milestone title
+        new_milestone_title = 'This is a test renaming a milestone title'
+        first_draft_milestone = draft.milestones[0]
+        first_draft_milestone.title = new_milestone_title
+
+        # persist changes
+        db.session.add(first_draft_milestone)
+        db.session.add(draft)
+        db.session.commit()
+
+        # publish live draft
+        resp = self.app.put(
+            f"/api/v1/proposals/{draft_id}/publish/live"
+        )
+        self.assert200(resp)
+        self.assertEqual(resp.json['proposalId'], self.proposal.id)
+
+        # check to see the changes have been copied to the proposal
+        proposal = Proposal.query.get(self.proposal.id)
+        self.assertEqual(proposal.title, new_draft_title)
+        self.assertEqual(proposal.milestones[0].title, new_milestone_title)
+
+        # check the draft has been destroyed
+        self.assertIsNone(proposal.live_draft)
+        old_live_draft = Proposal.query.get(draft_id)
+        self.assertIsNone(old_live_draft)
+
+    def test_publish_live_draft_bad_status_fail(self):
+        # publishing a live draft without a LIVE_DRAFT status should fail
+        self.login_default_user()
+        resp = self.app.put(
+            f"/api/v1/proposals/{self.proposal.id}/publish/live"
+        )
+        self.assert403(resp)
+
+    def test_publish_live_draft_bad_parent_fail(self):
+        # publishing a live draft without a valid parent should fail
+        self.login_default_user()
+        self.proposal.status = ProposalStatus.LIVE_DRAFT
+        db.session.add(self.proposal)
+        db.session.commit()
+        resp = self.app.put(
+            f"/api/v1/proposals/{self.proposal.id}/publish/live"
+        )
+        self.assert404(resp)
+
+        # publishing a live draft with an invalid parent should fail
+        self.proposal.live_draft_parent_id = 111111111111
+        resp = self.app.put(
+            f"/api/v1/proposals/{self.proposal.id}/publish/live"
+        )
+        self.assert404(resp)

--- a/frontend/.storybook/webpack.config.js
+++ b/frontend/.storybook/webpack.config.js
@@ -1,11 +1,13 @@
 const paths = require('../config/paths');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { client: clientLoaders } = require('../config/webpack.config.js/loaders');
 const { alias } = require('../config/webpack.config.js/resolvers');
 
 module.exports = (baseConfig, env, defaultConfig) => {
   const rules = [...baseConfig.module.rules, ...clientLoaders];
   baseConfig.module.rules = rules;
-  baseConfig.resolve.extensions.push('.ts', '.tsx', '.json');
+  baseConfig.resolve.extensions.push('.ts', '.tsx', '.json', '.less');
   baseConfig.resolve.alias = alias;
+  baseConfig.plugins.push(new MiniCssExtractPlugin());
   return baseConfig;
 };

--- a/frontend/stories/Proposal.story.tsx
+++ b/frontend/stories/Proposal.story.tsx
@@ -4,8 +4,8 @@ import { storiesOf } from '@storybook/react';
 import { ProposalCampaignBlock } from 'components/Proposal/CampaignBlock';
 
 import 'styles/style.less';
-import 'components/Proposal/style.less';
-import 'components/Proposal/Governance/style.less';
+import 'components/Proposal/index.less';
+// import 'components/Proposal/Governance/style.less';
 import { generateProposal } from './props';
 
 const user = {

--- a/frontend/stories/ProposalCard.story.tsx
+++ b/frontend/stories/ProposalCard.story.tsx
@@ -4,8 +4,8 @@ import { storiesOf } from '@storybook/react';
 import { ProposalCard } from 'components/Proposals/ProposalCard';
 
 import 'styles/style.less';
-import 'components/Proposal/style.less';
-import 'components/Proposal/Governance/style.less';
+import 'components/Proposal/index.less';
+// import 'components/Proposal/Governance/style.less';
 import { generateProposal } from './props';
 
 const propsNoFunding = generateProposal({

--- a/frontend/stories/ProposalMilestones.story.tsx
+++ b/frontend/stories/ProposalMilestones.story.tsx
@@ -3,15 +3,20 @@ import { storiesOf } from '@storybook/react';
 import { Provider } from 'react-redux';
 
 import { configureStore } from 'store/configure';
-import { combineInitialState } from 'store/reducers';
+import { combineInitialState as __combineInitialState } from 'store/reducers';
 import Milestones from 'components/Proposal/Milestones';
 import { MILESTONE_STAGE } from 'types';
 const { IDLE, ACCEPTED, PAID, REJECTED } = MILESTONE_STAGE;
 
 import 'styles/style.less';
-import 'components/Proposal/style.less';
-import 'components/Proposal/Governance/style.less';
+import 'components/Proposal/index.less';
+// import 'components/Proposal/Governance/style.less';
 import { generateProposal } from './props';
+
+const combineInitialState = {
+  web3: {},
+  ...__combineInitialState,
+};
 
 const msWaiting = { stage: IDLE };
 const msPaid = { stage: PAID };


### PR DESCRIPTION
Adds tests for the new API endpoints introduced in the other PRs and wires up new emails. New emails types are as follows:

 - `proposal_approved_discussion` - sent to a user when an admin approves the proposal to enter the public discussion status
 - `proposal_rejected_discussion` - sent to a user when an admin requests changes to a proposal already opened for public discussion
 - `admin_changes_resolved` - sent to admins when a user marks their `DISCUSSION` proposal as having resolved the requested changes
- `followed_proposal_revised` - sent to proposal followers whenever a revision has been made to a proposal
