### PR TITLE
Address Validation Refactor

### DIFF
--- a/admin/src/components/Financials/index.tsx
+++ b/admin/src/components/Financials/index.tsx
@@ -7,13 +7,11 @@ import Info from 'components/Info';
 import { formatUsd } from '../../util/formatters';
 import './index.less';
 
-interface Props {}
-
 interface State {
   selectedYear: string;
 }
 
-class Financials extends React.Component<Props, State> {
+class Financials extends React.Component<{}, State> {
   state: State = {
     selectedYear: '',
   };

--- a/admin/src/store.ts
+++ b/admin/src/store.ts
@@ -156,10 +156,7 @@ async function acceptProposal(
   return data;
 }
 
-async function rejectPermanentlyProposal(
-  id: number,
-  rejectReason: string,
-) {
+async function rejectPermanentlyProposal(id: number, rejectReason: string) {
   const { data } = await api.put(`/admin/proposals/${id}/reject_permanently`, {
     rejectReason,
   });
@@ -224,7 +221,6 @@ async function rejectPermanentlyCcr(id: number, rejectReason: string) {
   return data;
 }
 
-
 async function fetchCCRs(params: Partial<PageQuery>) {
   const { data } = await api.get(`/admin/ccrs`, { params });
   return data;
@@ -273,12 +269,12 @@ async function editContribution(id: number, args: ContributionArgs) {
   return data;
 }
 
-type QuarterData = {
-  q1: string
-  q2: string
-  q3: string
-  q4: string
-  yearTotal: string
+interface QuarterData {
+  q1: string;
+  q2: string;
+  q3: string;
+  q4: string;
+  yearTotal: string;
 }
 
 // STORE
@@ -316,7 +312,7 @@ const app = store({
       paid: '0',
       future: '0',
     },
-    payoutsByQuarter: {} as { [type: string]: QuarterData }
+    payoutsByQuarter: {} as { [type: string]: QuarterData },
   },
 
   users: {
@@ -632,7 +628,7 @@ const app = store({
     try {
       const { ccrId } = app.ccrDetail;
       await rejectPermanentlyCcr(ccrId, rejectReason);
-      await app.fetchCCRDetail(ccrId)
+      await app.fetchCCRDetail(ccrId);
     } catch (e) {
       handleApiError(e);
     }
@@ -739,7 +735,8 @@ const app = store({
 
   async rejectPermanentlyProposal(rejectReason: string) {
     if (!app.proposalDetail) {
-      const m = 'store.rejectPermanentlyProposal(): Expected proposalDetail to be populated!';
+      const m =
+        'store.rejectPermanentlyProposal(): Expected proposalDetail to be populated!';
       app.generalError.push(m);
       console.error(m);
       return;
@@ -761,19 +758,19 @@ const app = store({
       app.generalError.push(m);
       return;
     }
-    let success = false
-    app.proposalDetailMarkingChangesAsResolved = true
+    let success = false;
+    app.proposalDetailMarkingChangesAsResolved = true;
     try {
       const { proposalId } = app.proposalDetail;
       const res = await markProposalChangesAsResolved(proposalId);
       app.updateProposalInStore(res);
-      success = true
+      success = true;
     } catch (e) {
       handleApiError(e);
-      success = false
+      success = false;
     }
-    app.proposalDetailMarkingChangesAsResolved = false
-    return success
+    app.proposalDetailMarkingChangesAsResolved = false;
+    return success;
   },
 
   async cancelProposal(id: number) {

--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -25,7 +25,7 @@ from grant.utils.auth import (
     get_authed_user,
     internal_webhook
 )
-from grant.utils.requests import validate_blockchain_get
+from grant.utils.validate import is_z_address_valid
 from grant.utils.enums import Category
 from grant.utils.enums import ProposalStatus, ProposalStage, ContributionStatus, RFPStatus
 from grant.utils.exceptions import ValidationException
@@ -320,11 +320,11 @@ def resolve_changes_discussion(proposal_id):
     "viewKey": fields.Str(required=False, missing=None)
 })
 def update_proposal_tip_jar(proposal_id, address, view_key):
+    if address is not None and address is not '' and not is_z_address_valid(address):
+        return {"message": "Tip address is not a valid z address"}, 400
     if address is not None:
-        if address is not '':
-            validate_blockchain_get('/validate/address', {'address': address})
-
         g.current_proposal.tip_jar_address = address
+
     if view_key is not None:
         g.current_proposal.tip_jar_view_key = view_key
 

--- a/backend/grant/utils/bech32.py
+++ b/backend/grant/utils/bech32.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2017 Pieter Wuille
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Reference implementation for Bech32 and segwit addresses."""
+
+
+CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+
+def bech32_polymod(values):
+    """Internal function that computes the Bech32 checksum."""
+    generator = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+    chk = 1
+    for value in values:
+        top = chk >> 25
+        chk = (chk & 0x1ffffff) << 5 ^ value
+        for i in range(5):
+            chk ^= generator[i] if ((top >> i) & 1) else 0
+    return chk
+
+
+def bech32_hrp_expand(hrp):
+    """Expand the HRP into values for checksum computation."""
+    return [ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp]
+
+
+def bech32_verify_checksum(hrp, data):
+    """Verify a checksum given HRP and converted data characters."""
+    return bech32_polymod(bech32_hrp_expand(hrp) + data) == 1
+
+
+def bech32_create_checksum(hrp, data):
+    """Compute the checksum values given HRP and data."""
+    values = bech32_hrp_expand(hrp) + data
+    polymod = bech32_polymod(values + [0, 0, 0, 0, 0, 0]) ^ 1
+    return [(polymod >> 5 * (5 - i)) & 31 for i in range(6)]
+
+
+def bech32_encode(hrp, data):
+    """Compute a Bech32 string given HRP and data values."""
+    combined = data + bech32_create_checksum(hrp, data)
+    return hrp + '1' + ''.join([CHARSET[d] for d in combined])
+
+
+def bech32_decode(bech):
+    """Validate a Bech32 string, and determine HRP and data."""
+    if ((any(ord(x) < 33 or ord(x) > 126 for x in bech)) or
+            (bech.lower() != bech and bech.upper() != bech)):
+        return (None, None)
+    bech = bech.lower()
+    pos = bech.rfind('1')
+    if pos < 1 or pos + 7 > len(bech) or len(bech) > 90:
+        return (None, None)
+    if not all(x in CHARSET for x in bech[pos+1:]):
+        return (None, None)
+    hrp = bech[:pos]
+    data = [CHARSET.find(x) for x in bech[pos+1:]]
+    if not bech32_verify_checksum(hrp, data):
+        return (None, None)
+    return (hrp, data[:-6])
+
+
+def convertbits(data, frombits, tobits, pad=True):
+    """General power-of-2 base conversion."""
+    acc = 0
+    bits = 0
+    ret = []
+    maxv = (1 << tobits) - 1
+    max_acc = (1 << (frombits + tobits - 1)) - 1
+    for value in data:
+        if value < 0 or (value >> frombits):
+            return None
+        acc = ((acc << frombits) | value) & max_acc
+        bits += frombits
+        while bits >= tobits:
+            bits -= tobits
+            ret.append((acc >> bits) & maxv)
+    if pad:
+        if bits:
+            ret.append((acc << (tobits - bits)) & maxv)
+    elif bits >= frombits or ((acc << (tobits - bits)) & maxv):
+        return None
+    return ret
+
+
+def decode(hrp, addr):
+    """Decode a segwit address."""
+    hrpgot, data = bech32_decode(addr)
+    if hrpgot != hrp:
+        return (None, None)
+    decoded = convertbits(data[1:], 5, 8, False)
+    if decoded is None or len(decoded) < 2 or len(decoded) > 40:
+        return (None, None)
+    if data[0] > 16:
+        return (None, None)
+    if data[0] == 0 and len(decoded) != 20 and len(decoded) != 32:
+        return (None, None)
+    return (data[0], decoded)
+
+
+def encode(hrp, witver, witprog):
+    """Encode a segwit address."""
+    ret = bech32_encode(hrp, [witver] + convertbits(witprog, 8, 5))
+    if decode(hrp, ret) == (None, None):
+        return None
+    return ret

--- a/backend/grant/utils/requests.py
+++ b/backend/grant/utils/requests.py
@@ -29,20 +29,6 @@ def blockchain_get(path, params=None):
         raise e
 
 
-def validate_blockchain_get(path, params=None):
-    if path == '/validate/address' and params and params['address'] and params['address'][0] == 't':
-        raise ValidationException('T addresses are not allowed')
-
-    try:
-        res = blockchain_get(path, params)
-    except Exception:
-        raise ValidationException('Unable to validate zcash address right now, try again later')
-    if not res.get('valid'):
-        raise ValidationException('Invalid Zcash address')
-
-    return True
-
-
 def blockchain_post(path, data=None):
     if E2E_TESTING:
         return blockchain_rest_e2e(path, data)

--- a/backend/grant/utils/validate.py
+++ b/backend/grant/utils/validate.py
@@ -1,0 +1,19 @@
+from grant.utils.bech32 import bech32_decode
+
+
+def is_z_address_valid(addr: str):
+    if type(addr) != str:
+        return False
+
+    if addr[:3] != 'zs1':
+        return False
+
+    hrp, data = bech32_decode(addr)
+
+    if hrp is None:
+        return False
+
+    if data is None:
+        return False
+
+    return True

--- a/backend/tests/admin/test_admin_api.py
+++ b/backend/tests/admin/test_admin_api.py
@@ -243,8 +243,7 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         # 2 proposals created by BaseProposalCreatorConfig
         self.assertEqual(len(resp.json['items']), 2)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_open_proposal_for_discussion_accept(self, mock_get):
+    def test_open_proposal_for_discussion_accept(self):
         # an admin should be able to open a proposal for discussion
         self.login_admin()
 
@@ -263,8 +262,7 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         proposal = Proposal.query.get(self.proposal.id)
         self.assertEqual(proposal.status, ProposalStatus.DISCUSSION)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_open_proposal_for_discussion_reject(self, mock_get):
+    def test_open_proposal_for_discussion_reject(self):
         # an admin should be able to reject opening a proposal for discussion
         reject_reason = "this is a test"
 
@@ -287,8 +285,7 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         self.assertEqual(proposal.status, ProposalStatus.REJECTED)
         self.assertEqual(proposal.reject_reason, reject_reason)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_open_proposal_for_discussion_bad_proposal_id_fail(self, mock_get):
+    def test_open_proposal_for_discussion_bad_proposal_id_fail(self):
         # request should fail if a bad proposal id is provided
         bad_proposal_id = "11111111111111111111"
         self.login_admin()
@@ -300,8 +297,7 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         )
         self.assert404(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_open_proposal_for_discussion_not_admin_fail(self, mock_get):
+    def test_open_proposal_for_discussion_not_admin_fail(self):
         # request should fail if user is not an admin
         self.login_default_user()
 
@@ -315,8 +311,7 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         )
         self.assert401(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_open_proposal_for_discussion_not_pending_fail(self, mock_get):
+    def test_open_proposal_for_discussion_not_pending_fail(self):
         # request should fail if proposal is not in PENDING state
         self.login_admin()
 
@@ -329,8 +324,7 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         )
         self.assert400(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_open_proposal_for_discussion_no_reject_reason_fail(self, mock_get):
+    def test_open_proposal_for_discussion_no_reject_reason_fail(self):
         # denying opening a proposal for discussion should fail if no reason is provided
         self.login_admin()
 
@@ -344,8 +338,7 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         )
         self.assert400(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_accept_proposal_with_funding(self, mock_get):
+    def test_accept_proposal_with_funding(self):
         self.login_admin()
 
         # proposal needs to be DISCUSSION
@@ -366,8 +359,7 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         for milestone in resp.json["milestones"]:
             self.assertIsNotNone(milestone["dateEstimated"])
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_accept_proposal_without_funding(self, mock_get):
+    def test_accept_proposal_without_funding(self):
         self.login_admin()
 
         # proposal needs to be DISCUSSION
@@ -504,8 +496,7 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         )
         self.assert400(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_change_proposal_to_accepted_with_funding(self, mock_get):
+    def test_change_proposal_to_accepted_with_funding(self):
         self.login_admin()
 
         # proposal needs to be DISCUSSION
@@ -556,8 +547,7 @@ class TestAdminAPI(BaseProposalCreatorConfig):
         self.assert404(resp)
         self.assertEqual(resp.json["message"], 'Only live or approved proposals can be modified by this endpoint')
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_reject_proposal_discussion(self, mock_get):
+    def test_reject_proposal_discussion(self):
         self.login_admin()
 
         # proposal needs to be PENDING

--- a/backend/tests/config.py
+++ b/backend/tests/config.py
@@ -174,8 +174,7 @@ class BaseProposalCreatorConfig(BaseUserConfig):
         proposal_reminder = ProposalReminder(self.proposal.id)
         proposal_reminder.make_task()
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def stake_proposal(self, mock_get):
+    def stake_proposal(self):
         # 1. submit
         self.proposal.submit_for_approval()
         # 2. get staking contribution

--- a/backend/tests/milestone/test_milestone_methods.py
+++ b/backend/tests/milestone/test_milestone_methods.py
@@ -49,7 +49,7 @@ test_proposal = {
     "milestones": test_milestones,
     "category": Category.ACCESSIBILITY,
     "target": "12345",
-    "payoutAddress": "123",
+    "payoutAddress": "zs15el0hzs4w60ggfy6kq4p3zttjrl00mfq7yxfwsjqpz9d7hptdtkltzlcqar994jg2ju3j9k85zk",
 }
 
 
@@ -83,8 +83,7 @@ class TestMilestoneMethods(BaseUserConfig):
         print(proposal_schema.dump(proposal))
         return proposal
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_set_v2_date_estimates(self, mock_get):
+    def test_set_v2_date_estimates(self):
         proposal_data = test_proposal.copy()
         proposal = self.init_proposal(proposal_data)
         total_days_estimated = 0
@@ -112,8 +111,7 @@ class TestMilestoneMethods(BaseUserConfig):
         tasks = Task.query.filter_by(job_type=MilestoneDeadline.JOB_TYPE).all()
         self.assertEqual(len(tasks), 1)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_set_v2_date_estimates_immediate_payout(self, mock_get):
+    def test_set_v2_date_estimates_immediate_payout(self):
         proposal_data = test_proposal.copy()
         proposal_data["milestones"][0]["immediate_payout"] = True
 
@@ -123,8 +121,7 @@ class TestMilestoneMethods(BaseUserConfig):
         # ensure MilestoneDeadline task not created when immediate payout is set
         self.assertEqual(len(tasks), 0)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_set_v2_date_estimates_deadline_recalculation(self, mock_get):
+    def test_set_v2_date_estimates_deadline_recalculation(self):
         proposal_data = test_proposal.copy()
         proposal = self.init_proposal(proposal_data)
 

--- a/backend/tests/proposal/test_api.py
+++ b/backend/tests/proposal/test_api.py
@@ -62,8 +62,7 @@ class TestProposalAPI(BaseProposalCreatorConfig):
         )
         self.assert401(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_update_live_proposal_fails(self, mock_get):
+    def test_update_live_proposal_fails(self):
         self.login_default_user()
         self.proposal.status = ProposalStatus.APPROVED
         resp = self.app.put("/api/v1/proposals/{}/publish".format(self.proposal.id))
@@ -121,46 +120,40 @@ class TestProposalAPI(BaseProposalCreatorConfig):
         self.assert404(resp)
 
     # /submit_for_approval
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_proposal_draft_submit_for_approval(self, mock_get):
+    def test_proposal_draft_submit_for_approval(self):
         self.login_default_user()
         resp = self.app.put("/api/v1/proposals/{}/submit_for_approval".format(self.proposal.id))
         self.assert200(resp)
         self.assertEqual(resp.json['status'], ProposalStatus.PENDING)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_no_auth_proposal_draft_submit_for_approval(self, mock_get):
+    def test_no_auth_proposal_draft_submit_for_approval(self):
         resp = self.app.put("/api/v1/proposals/{}/submit_for_approval".format(self.proposal.id))
         self.assert401(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_invalid_proposal_draft_submit_for_approval(self, mock_get):
+    def test_invalid_proposal_draft_submit_for_approval(self):
         self.login_default_user()
         resp = self.app.put("/api/v1/proposals/12345/submit_for_approval")
         self.assert404(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_invalid_status_proposal_draft_submit_for_approval(self, mock_get):
+    def test_invalid_status_proposal_draft_submit_for_approval(self):
         self.login_default_user()
         self.proposal.status = ProposalStatus.PENDING  # should be ProposalStatus.DRAFT
         resp = self.app.put("/api/v1/proposals/{}/submit_for_approval".format(self.proposal.id))
         self.assert400(resp)
 
-    @patch('requests.get', side_effect=mock_invalid_address)
-    def test_invalid_address_proposal_draft_submit_for_approval(self, mock_get):
+    def test_invalid_address_proposal_draft_submit_for_approval(self):
         self.login_default_user()
+        self.proposal.payout_address = 'invalid'
         resp = self.app.put("/api/v1/proposals/{}/submit_for_approval".format(self.proposal.id))
         self.assert400(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_invalid_status_proposal_publish_proposal(self, mock_get):
+    def test_invalid_status_proposal_publish_proposal(self):
         self.login_default_user()
         self.proposal.status = ProposalStatus.PENDING  # should be ProposalStatus.APPROVED
         resp = self.app.put("/api/v1/proposals/{}/publish".format(self.proposal.id))
         self.assert400(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_not_verified_email_address_publish_proposal(self, mock_get):
+    def test_not_verified_email_address_publish_proposal(self):
         self.login_default_user()
         self.mark_user_not_verified()
         self.proposal.status = "DRAFT"
@@ -407,8 +400,7 @@ class TestProposalAPI(BaseProposalCreatorConfig):
         )
         self.assert404(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_publish_live_draft(self, mock_get):
+    def test_publish_live_draft(self):
         # user should be able to publish live draft of a proposal
         self.login_default_user()
         self.proposal.status = ProposalStatus.DISCUSSION
@@ -496,8 +488,7 @@ class TestProposalAPI(BaseProposalCreatorConfig):
         )
         self.assert404(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def get_proposal_revisions(self, mock_get):
+    def get_proposal_revisions(self):
         # user should be able to publish live draft of a proposal
         self.login_default_user()
         self.proposal.status = ProposalStatus.DISCUSSION

--- a/backend/tests/proposal/test_tips_api.py
+++ b/backend/tests/proposal/test_tips_api.py
@@ -5,7 +5,7 @@ from mock import patch
 from ..test_data import mock_blockchain_api_requests
 
 address_json = {
-    "address": "valid_address"
+    "address": "zs15el0hzs4w60ggfy6kq4p3zttjrl00mfq7yxfwsjqpz9d7hptdtkltzlcqar994jg2ju3j9k85zk"
 }
 
 view_key_json = {
@@ -15,8 +15,7 @@ view_key_json = {
 
 class TestProposalInviteAPI(BaseProposalCreatorConfig):
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_set_proposal_tip_address(self, mock_get):
+    def test_set_proposal_tip_address(self):
         self.login_default_user()
         res = self.app.put(
             f"/api/v1/proposals/{self.proposal.id}/tips",
@@ -27,8 +26,7 @@ class TestProposalInviteAPI(BaseProposalCreatorConfig):
         proposal = Proposal.query.get(self.proposal.id)
         self.assertEqual(proposal.tip_jar_address, address_json["address"])
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_set_proposal_tip_view_key(self, mock_get):
+    def test_set_proposal_tip_view_key(self):
         self.login_default_user()
         res = self.app.put(
             f"/api/v1/proposals/{self.proposal.id}/tips",

--- a/backend/tests/task/test_api.py
+++ b/backend/tests/task/test_api.py
@@ -181,8 +181,7 @@ class TestTaskAPI(BaseProposalCreatorConfig):
 
     @patch('grant.task.jobs.send_email')
     @patch('grant.task.views.datetime')
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_milestone_deadline(self, mock_get, mock_datetime, mock_send_email):
+    def test_milestone_deadline(self, mock_datetime, mock_send_email):
         tasks = Task.query.filter_by(completed=False).all()
         self.assertEqual(len(tasks), 0)
 

--- a/backend/tests/test_data.py
+++ b/backend/tests/test_data.py
@@ -45,7 +45,7 @@ test_proposal = {
     "milestones": milestones,
     "category": Category.ACCESSIBILITY,
     "target": "12345",
-    "payoutAddress": "123",
+    "payoutAddress": "zs15el0hzs4w60ggfy6kq4p3zttjrl00mfq7yxfwsjqpz9d7hptdtkltzlcqar994jg2ju3j9k85zk",
     "deadlineDuration": 100
 }
 

--- a/backend/tests/user/test_user_api.py
+++ b/backend/tests/user/test_user_api.py
@@ -386,9 +386,8 @@ class TestUserAPI(BaseUserConfig):
         )
         self.assert400(resp)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_put_user_settings_tip_jar_address(self, mock_get):
-        address = "address"
+    def test_put_user_settings_tip_jar_address(self):
+        address = "zs15el0hzs4w60ggfy6kq4p3zttjrl00mfq7yxfwsjqpz9d7hptdtkltzlcqar994jg2ju3j9k85zk"
 
         self.login_default_user()
         resp = self.app.put(
@@ -401,8 +400,7 @@ class TestUserAPI(BaseUserConfig):
         user = User.query.get(self.user.id)
         self.assertEqual(user.settings.tip_jar_address, address)
 
-    @patch('requests.get', side_effect=mock_blockchain_api_requests)
-    def test_put_user_settings_tip_jar_view_key(self, mock_get):
+    def test_put_user_settings_tip_jar_view_key(self):
         view_key = "view_key"
 
         self.login_default_user()

--- a/backend/tests/utils/test_validate.py
+++ b/backend/tests/utils/test_validate.py
@@ -1,0 +1,47 @@
+
+from ..config import BaseTestConfig
+from grant.utils.validate import is_z_address_valid
+
+
+good_addresses = [
+    "zs15el0hzs4w60ggfy6kq4p3zttjrl00mfq7yxfwsjqpz9d7hptdtkltzlcqar994jg2ju3j9k85zk",
+    "zs15xh8vjmlnqknztlgs7s8cu9wlj4rnd0m7hpyjwkjehalhlgwhfkvqnp8ycdpvhzfwywnc9r7yqs",
+    "zs1h6u0s750jtqthyf5dcck5xgvhadfsvp6vj0meem9y8ledq5r7gc6fnrgeseeprnmkzfwk8x4erc",
+    "zs1ke0qynx5hvx6rkqk2cg6eg2cdc7kn6ugs7ye0907pr6d09d6dsmzcxzhpawpcj73nk4svc6ualm",
+    "zs1m576g2evlaem403jlam3s08aned3srg5cvwphm4w7jjxylxsulzegusjpjxstau0klzckhld4s4",
+    "zs1su7cu6kgxp8luxs4rvvy4rd42caau7jkxmaufmj5ny6e8nuctuw4cptepjff6m8kvnsdywt733k",
+    "zs1qyk7tqzgreu9qsxs6ze0ptgm7tlr9j9e2dumqv5en7whhwwznscll49nteghtegz4mvtj7nt304",
+    "zs15vku5xmethefjarje8e9ee82znhtzlyesskee5fz0kge3m4sealp3xaqdx2se6gj2e2uzw5amnz",
+    "zs1szg7qncv0ywjppttagxecetlr5gler7uwcqdcfrshugh27l8mux209ff243fy60svphzvz8fss0",
+    "zs1rdk0xkrk2mxjge33su9fshxzrdpg5hz25zutl82l6gjyz5ph5lw9hhtd759hdg8qqttyxpqudxc"
+
+]
+
+bad_addresses = [
+    False,
+    3,
+    "cs15el0hzs4w60ggfy6kq4p3zttjrl00mfq7yxfwsjqpz9d7hptdtkltzlcqar994jg2ju3j9k85zk",
+    "zs15el0hzs4w60ggfy6kq4p3zttjrl00mfq7yxfwsjqpz9ddhptdtkltzlcqar994jg2ju3j9k85zz",
+    "zs15xh8vjmlnqknztlgs7s8cu9wlj4r0d0m7hpyjwkjehalhlgwhfkvqnp8ycdpvhzfwywnc9r7yqs",
+    "zs1h6u0s750jtqthyf5dcck5xgvhadfsvp6vj0eeem9y8ledq5r7gc6fnrgeseeprnmkzfwk8x4erc",
+    "zs1ke0qynx5hvx6rkqk2cg6eg2cdc7kn6ugs7yd0907pr6d09d6dsmzcxzhpawpcj73nk4svc6ualm",
+    "zs1m576g2evlaem403jlam3s08aned3srg5cvwph4w7jjxylxsulzegusjpjxstau0klzckhld4s4",
+    "zs1su7cu6kgxp8luxs4rvvy4rd42caau7jkxmauhfmj5ny6e8nuctuw4cptepjff6m8kvnsdywt733k",
+    "zs1qyk7tqzgreu9qsxs6ze0ptgm7tlr9j9e2duv5en7whhwwznscll49nteghtegz4mvtj7nt304",
+    "zs15vku5xmethefjarje8e9ee82znhtzlzwyesskee5fz0kge3m4sealp3xaqdx2se6gj2e2uzw5amnz",
+    "zs1szg7qncv0ywjppttagxecetlr5gler70wcqdcfrshugh27l8mux209ff243fy60svphzvz8fss0",
+    "zs1rdk0xkrk2mxjge33su9fshxzrdpg5hz25zutl82l6gjyz5ph5tw9hhtd759hdg8qqttyxpqudxc"
+]
+
+
+class TestValidate(BaseTestConfig):
+
+    def test_good_addresses_should_be_valid(self):
+        for addr in good_addresses:
+            is_valid = is_z_address_valid(addr)
+            self.assertTrue(is_valid)
+
+    def test_bad_addresses_should_be_invalid(self):
+        for addr in bad_addresses:
+            is_valid = is_z_address_valid(addr)
+            self.assertFalse(is_valid)

--- a/backend/tests/utils/test_validate.py
+++ b/backend/tests/utils/test_validate.py
@@ -18,8 +18,10 @@ good_addresses = [
 ]
 
 bad_addresses = [
+    None,
     False,
     3,
+    "",
     "cs15el0hzs4w60ggfy6kq4p3zttjrl00mfq7yxfwsjqpz9d7hptdtkltzlcqar994jg2ju3j9k85zk",
     "zs15el0hzs4w60ggfy6kq4p3zttjrl00mfq7yxfwsjqpz9ddhptdtkltzlcqar994jg2ju3j9k85zz",
     "zs15xh8vjmlnqknztlgs7s8cu9wlj4r0d0m7hpyjwkjehalhlgwhfkvqnp8ycdpvhzfwywnc9r7yqs",

--- a/frontend/client/components/CCRFlow/Basics.tsx
+++ b/frontend/client/components/CCRFlow/Basics.tsx
@@ -64,7 +64,7 @@ class CCRFlowBasics extends React.Component<Props, State> {
         >
           <Input.TextArea
             name="brief"
-            placeholder="An elevator-pitch version of your request, max 140 chars"
+            placeholder="An elevator-pitch version of your request, max 140 chars. Please no page breaks"
             value={brief}
             onChange={this.handleInputChange}
             rows={3}

--- a/frontend/client/components/CreateFlow/Basics.tsx
+++ b/frontend/client/components/CreateFlow/Basics.tsx
@@ -146,7 +146,7 @@ class CreateFlowBasics extends React.Component<Props, State> {
         >
           <Input.TextArea
             name="brief"
-            placeholder="An elevator-pitch version of your proposal, max 140 chars"
+            placeholder="An elevator-pitch version of your proposal, max 140 chars. Please no page breaks"
             value={brief}
             onChange={this.handleInputChange}
             rows={3}


### PR DESCRIPTION
Closes #136. Depends on #133.

Implements strategy to validate z addresses on the backend, rather than calling out to a node. 

Also updates brief placeholders for Proposals and  CCRs.