### PR TITLE
QA - Larger Fixes 8

### DIFF
--- a/frontend/client/components/Proposals/Filters/index.tsx
+++ b/frontend/client/components/Proposals/Filters/index.tsx
@@ -24,20 +24,6 @@ interface OwnProps {
 type Props = OwnProps & RouteComponentProps<any>;
 
 class ProposalFilters extends React.Component<Props> {
-  private getFilterFromUrl(
-    location: RouteComponentProps['location'],
-  ): string | undefined {
-    const args = qs.parse(location.search);
-    return args.filter;
-  }
-
-  private getActiveFilter(): string {
-    const { filters } = this.props;
-    const combinedFilters = [...filters.stage, ...filters.custom];
-
-    return combinedFilters.length ? combinedFilters[0].toUpperCase() : 'ALL';
-  }
-
   componentDidMount() {
     const urlFilter = this.getFilterFromUrl(this.props.location);
 
@@ -116,6 +102,20 @@ class ProposalFilters extends React.Component<Props> {
         </Card>
       </div>
     );
+  }
+
+  private getFilterFromUrl(
+    location: RouteComponentProps['location'],
+  ): string | undefined {
+    const args = qs.parse(location.search);
+    return args.filter;
+  }
+
+  private getActiveFilter(): string {
+    const { filters } = this.props;
+    const combinedFilters = [...filters.stage, ...filters.custom];
+
+    return combinedFilters.length ? combinedFilters[0].toUpperCase() : 'ALL';
   }
 
   private handleStageChange = (ev: RadioChangeEvent) => {

--- a/frontend/client/components/Proposals/Filters/index.tsx
+++ b/frontend/client/components/Proposals/Filters/index.tsx
@@ -43,19 +43,21 @@ class ProposalFilters extends React.Component<Props> {
 
     if (!urlFilter) return;
 
-    const urlFilterUpper = urlFilter.toUpperCase();
+    const filterMap: { [key: string]: string } = {
+      with_funding: 'ACCEPTED_WITH_FUNDING',
+      without_funding: 'ACCEPTED_WITHOUT_FUNDING',
+      public_review: 'STATUS_DISCUSSION',
+      in_progress: 'WIP',
+      completed: 'COMPLETED',
+    };
+    const translatedFilter = filterMap[urlFilter.toLowerCase()];
+
+    if (!translatedFilter) return;
+
     const activeFilter = this.getActiveFilter();
-    const filtersWhitelist = [
-      ...Object.values(PROPOSAL_STAGE),
-      ...Object.values(CUSTOM_FILTERS),
-    ];
 
-    if (!filtersWhitelist.includes(urlFilterUpper as any)) {
-      return;
-    }
-
-    if (urlFilterUpper !== activeFilter) {
-      this.handleStageChange({ target: { value: urlFilterUpper } } as RadioChangeEvent);
+    if (translatedFilter !== activeFilter) {
+      this.handleStageChange({ target: { value: translatedFilter } } as RadioChangeEvent);
     }
   }
 


### PR DESCRIPTION
Derives active filter on proposal page from `filter` query parameter. The following keys can be used to set the active filter: `with_funding`, `without_funding`, `public_review`, `in_progress`, `completed`.

For example, this URL will open up the proposals page with completed filter set: `http://localhost:3000/proposals?filter=completed`. 