### PR TITLE
QA - Larger Fixes 6, 7

### DIFF
--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -988,6 +988,23 @@ class Proposal(db.Model):
                 db.session.delete(live_draft)
                 return False
 
+        # if this is the first revision, create a base revision that's a snapshot of the original proposal
+        if len(self.revisions) == 0:
+            base_draft = self.make_live_draft(self)
+            base_draft.status = ProposalStatus.ARCHIVED
+            base_draft.invites = []
+
+            db.session.add(base_draft)
+
+            base_revision = ProposalRevision(
+                author=author,
+                proposal_id=self.id,
+                proposal_archive_id=base_draft.id,
+                changes=json.dumps([]),
+                revision_index=0
+            )
+            self.revisions.append(base_revision)
+
         revision_index = len(self.revisions)
 
         revision = ProposalRevision(

--- a/backend/grant/proposal/models.py
+++ b/backend/grant/proposal/models.py
@@ -964,7 +964,6 @@ class Proposal(db.Model):
         live_draft_proposal.changes_requested_discussion_reason = proposal.changes_requested_discussion_reason
         live_draft_proposal.rfp_opt_in = proposal.rfp_opt_in
         live_draft_proposal.team = proposal.team
-        live_draft_proposal.invites = proposal.invites
 
         db.session.add(live_draft_proposal)
 
@@ -978,11 +977,18 @@ class Proposal(db.Model):
         revision_changes = ProposalRevision.calculate_proposal_changes(self, live_draft)
 
         if len(revision_changes) == 0:
-            if live_draft.rfp_opt_in == self.rfp_opt_in:
+            if live_draft.rfp_opt_in == self.rfp_opt_in \
+                    and live_draft.payout_address == self.payout_address \
+                    and live_draft.tip_jar_address == self.tip_jar_address \
+                    and live_draft.team == self.team:
+
                 raise ValidationException("Live draft does not appear to have any changes")
             else:
-                # cover special case where ONLY kyc selection has changed without any publishable revision changes
+                # cover special cases where properties not tracked in revisions have changed:
                 self.rfp_opt_in = live_draft.rfp_opt_in
+                self.payout_address = live_draft.payout_address
+                self.tip_jar_address = live_draft.tip_jar_address
+                self.team = live_draft.team
                 self.live_draft = None
                 db.session.add(self)
                 db.session.delete(live_draft)
@@ -1023,7 +1029,7 @@ class Proposal(db.Model):
         self.tip_jar_address = live_draft.tip_jar_address
         self.rfp_opt_in = live_draft.rfp_opt_in
         self.team = live_draft.team
-        self.invites = live_draft.invites
+        self.invites = []
         self.live_draft = None
 
         self.revisions.append(revision)
@@ -1035,6 +1041,7 @@ class Proposal(db.Model):
 
         # archive live draft
         live_draft.status = ProposalStatus.ARCHIVED
+        live_draft.invites = []
         db.session.add(live_draft)
         return True
 

--- a/backend/tests/proposal/test_api.py
+++ b/backend/tests/proposal/test_api.py
@@ -450,17 +450,25 @@ class TestProposalAPI(BaseProposalCreatorConfig):
         old_live_draft = Proposal.query.get(draft_id)
         self.assertEqual(old_live_draft.status, ProposalStatus.ARCHIVED)
 
-        # check the proposal revision was added
-        self.assertEqual(len(self.proposal.revisions), 1)
+        # check the proposal revision and base snapshot was added
+        self.assertEqual(len(self.proposal.revisions), 2)
+
+        # check the base snapshot was created correctly
+        base_revision = self.proposal.revisions[0]
+        self.assertEqual(base_revision.author, self.user)
+        self.assertEqual(base_revision.proposal, self.proposal)
+        self.assertIsNotNone(base_revision.proposal_archive_id)
+        self.assertNotEqual(base_revision.proposal_archive_id, draft_id)
+        self.assertEqual(len(json.loads(base_revision.changes)), 0)
+        self.assertEqual(base_revision.revision_index, 0)
 
         # check the proposal revision was created correctly
-        revision = self.proposal.revisions[0]
+        revision = self.proposal.revisions[1]
         self.assertEqual(revision.author, self.user)
         self.assertEqual(revision.proposal, self.proposal)
         self.assertEqual(revision.proposal_archive_id, draft_id)
-        self.assertGreater(len(revision.changes), 0)
-        self.assertEqual(revision.revision_index, 0)
-
+        self.assertEqual(len(json.loads(revision.changes)), 2)
+        self.assertEqual(revision.revision_index, 1)
 
     def test_publish_live_draft_bad_status_fail(self):
         # publishing a live draft without a LIVE_DRAFT status should fail

--- a/backend/tests/proposal/test_api.py
+++ b/backend/tests/proposal/test_api.py
@@ -413,6 +413,8 @@ class TestProposalAPI(BaseProposalCreatorConfig):
             f"/api/v1/proposals/{self.proposal.id}/draft"
         )
 
+        print('draft', draft_resp.json, '\n\n')
+
         # check the two proposals have been related correctly
         self.assertStatus(draft_resp, 201)
         self.assertNotEqual(draft_resp.json['proposalId'], self.proposal.id)
@@ -453,22 +455,25 @@ class TestProposalAPI(BaseProposalCreatorConfig):
         # check the proposal revision and base snapshot was added
         self.assertEqual(len(self.proposal.revisions), 2)
 
+        def find_revision_with_index(revisions, index):
+            return next((r for r in revisions if r.revision_index == index), None)
+
         # check the base snapshot was created correctly
-        base_revision = self.proposal.revisions[0]
+        base_revision = find_revision_with_index(self.proposal.revisions, 0)
+        self.assertEqual(base_revision.revision_index, 0)
         self.assertEqual(base_revision.author, self.user)
         self.assertEqual(base_revision.proposal, self.proposal)
         self.assertIsNotNone(base_revision.proposal_archive_id)
         self.assertNotEqual(base_revision.proposal_archive_id, draft_id)
         self.assertEqual(len(json.loads(base_revision.changes)), 0)
-        self.assertEqual(base_revision.revision_index, 0)
 
         # check the proposal revision was created correctly
-        revision = self.proposal.revisions[1]
+        revision = find_revision_with_index(proposal.revisions, 1)
+        self.assertEqual(revision.revision_index, 1)
         self.assertEqual(revision.author, self.user)
         self.assertEqual(revision.proposal, self.proposal)
         self.assertEqual(revision.proposal_archive_id, draft_id)
         self.assertEqual(len(json.loads(revision.changes)), 2)
-        self.assertEqual(revision.revision_index, 1)
 
     def test_publish_live_draft_bad_status_fail(self):
         # publishing a live draft without a LIVE_DRAFT status should fail

--- a/backend/tests/proposal/test_api.py
+++ b/backend/tests/proposal/test_api.py
@@ -413,8 +413,6 @@ class TestProposalAPI(BaseProposalCreatorConfig):
             f"/api/v1/proposals/{self.proposal.id}/draft"
         )
 
-        print('draft', draft_resp.json, '\n\n')
-
         # check the two proposals have been related correctly
         self.assertStatus(draft_resp, 201)
         self.assertNotEqual(draft_resp.json['proposalId'], self.proposal.id)

--- a/frontend/client/components/Proposal/Revisions/index.tsx
+++ b/frontend/client/components/Proposal/Revisions/index.tsx
@@ -52,29 +52,45 @@ export class ProposalRevision extends React.Component<Props> {
     } else if (revisionsError) {
       content = <Placeholder title="Something went wrong" subtitle={revisionsError} />;
     } else if (revisions) {
-      if (revisions.length) {
+      if (revisions.length >= 2) {
         revisions.reverse();
         content = revisions.map((revision, index) => (
           <div key={revision.revisionId} className="ProposalRevision-revision">
-            <h3 className="ProposalRevision-revision-title">
-              {moment(revision.dateCreated * 1000).format('MMMM Do, YYYY')}
-            </h3>
-            <div className="ProposalRevision-revision-date">
-              {`Revision ${revision.revisionIndex + 1}`}
-            </div>
-            <div className="ProposalRevision-revision-body">
-              {this.renderRevisionBody(revision)}
-            </div>
-            <div className="ProposalRevision-revision-controls">
-              {index !== 0 && (
-                <Link
-                  to={`/proposals/${revision.proposalArchiveId}/archive`}
-                  className="ProposalRevision-revision-controls-button"
-                >
-                  View archived
-                </Link>
-              )}
-            </div>
+            {index === revisions.length - 1 ? (
+              <>
+                <h3 className="ProposalRevision-revision-title">Original Proposal</h3>
+                <div className="ProposalRevision-revision-controls">
+                  <Link
+                    to={`/proposals/${revision.proposalArchiveId}/archive`}
+                    className="ProposalRevision-revision-controls-button"
+                  >
+                    View archived
+                  </Link>
+                </div>
+              </>
+            ) : (
+              <>
+                <h3 className="ProposalRevision-revision-title">
+                  {moment(revision.dateCreated * 1000).format('MMMM Do, YYYY')}
+                </h3>
+                <div className="ProposalRevision-revision-date">
+                  {`Revision ${revision.revisionIndex}`}
+                </div>
+                <div className="ProposalRevision-revision-body">
+                  {this.renderRevisionBody(revision)}
+                </div>
+                <div className="ProposalRevision-revision-controls">
+                  {index !== 0 && (
+                    <Link
+                      to={`/proposals/${revision.proposalArchiveId}/archive`}
+                      className="ProposalRevision-revision-controls-button"
+                    >
+                      View archived
+                    </Link>
+                  )}
+                </div>
+              </>
+            )}
           </div>
         ));
       } else {


### PR DESCRIPTION
- Allows proposal edits to go through even if they only change payout address, tip jar address, or add team members
- Clears pending invites between proposal edits
- Creates an Original Proposal entry on first revision