### PR TITLE
Poll for Team and Invite Changes in Create Flow

### DIFF
--- a/backend/grant/proposal/views.py
+++ b/backend/grant/proposal/views.py
@@ -508,7 +508,12 @@ def post_proposal_update(proposal_id, title, content):
 @blueprint.route("/<proposal_id>/invites", methods=["GET"])
 @requires_team_member_auth
 def get_proposal_team_invites(proposal_id):
-    return proposal_team_invites_schema.dump(g.current_proposal.invites)
+    proposal_dump = proposal_schema.dump(g.current_proposal)
+    return {
+        "team": proposal_dump["team"],
+        "invites": proposal_dump["invites"]
+    }
+
 
 @blueprint.route("/<proposal_id>/invite", methods=["POST"])
 @limiter.limit("30/day;10/minute")

--- a/frontend/client/api/api.ts
+++ b/frontend/client/api/api.ts
@@ -109,7 +109,7 @@ export function getUser(address: string): Promise<{ data: User }> {
         withFunded: true,
         withPending: true,
         withArbitrated: true,
-        withRejectedPermanently: true
+        withRejectedPermanently: true,
       },
     })
     .then(res => {
@@ -352,8 +352,8 @@ export async function rejectProposalPayout(
 }
 
 export function getProposalInvites(
-  proposalId: number
-): Promise<{ data: TeamInvite[] }> {
+  proposalId: number,
+): Promise<{ data: { invites: TeamInvite[], team: User[] } }> {
   return axios.get(`/api/v1/proposals/${proposalId}/invites`);
 }
 

--- a/frontend/client/components/CreateFlow/index.tsx
+++ b/frontend/client/components/CreateFlow/index.tsx
@@ -6,6 +6,7 @@ import qs from 'query-string';
 import { withRouter, RouteComponentProps } from 'react-router';
 import { History } from 'history';
 import { debounce } from 'underscore';
+import { isEqual } from 'lodash';
 import Basics from './Basics';
 import Team from './Team';
 import Details from './Details';
@@ -127,11 +128,35 @@ interface State {
   isSubmitting: boolean;
   isExplaining: boolean;
   isExample: boolean;
+  isPolling: boolean;
 }
+
+const TEAM_CHANGE_POLL_INTERVAL = 5000;
 
 class CreateFlow extends React.Component<Props, State> {
   private historyUnlisten: () => void;
   private debouncedUpdateForm: (form: Partial<ProposalDraft>) => void;
+  private pollInterval: ReturnType<typeof setInterval> | undefined;
+
+  private pollForTeamChanges = async () => {
+    const { form } = this.props;
+
+    if (this.state.isPolling) return;
+    if (form) {
+      this.setState({ isPolling: true });
+      try {
+        const {
+          data: { invites, team },
+        } = await getProposalInvites(form.proposalId);
+
+        if (!isEqual(form.invites, invites) || !isEqual(form.team, team)) {
+          this.updateForm({ invites, team });
+        }
+        // tslint:disable-next-line:no-empty
+      } catch {}
+      this.setState({ isPolling: false });
+    }
+  };
 
   constructor(props: Props) {
     super(props);
@@ -150,14 +175,26 @@ class CreateFlow extends React.Component<Props, State> {
       isExample: false,
       isShowingSubmitWarning: false,
       isExplaining: !noExplain,
+      isPolling: false,
     };
     this.debouncedUpdateForm = debounce(this.updateForm, 800);
     this.historyUnlisten = this.props.history.listen(this.handlePop);
   }
 
+  componentWillMount() {
+    if (!this.pollInterval) {
+      this.pollInterval = setInterval(this.pollForTeamChanges, TEAM_CHANGE_POLL_INTERVAL);
+    }
+  }
+
   componentWillUnmount() {
     if (this.historyUnlisten) {
       this.historyUnlisten();
+    }
+
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
+      this.pollInterval = undefined;
     }
   }
 
@@ -339,14 +376,6 @@ class CreateFlow extends React.Component<Props, State> {
   };
 
   private openPublishWarning = async () => {
-    if (this.props.form) {
-      try {
-        const { data: invites } = await getProposalInvites(this.props.form.proposalId);
-        this.updateForm({ invites });
-        // tslint:disable-next-line:no-empty
-      } catch {}
-    }
-
     this.setState({ isShowingSubmitWarning: true });
   };
 

--- a/frontend/client/components/CreateFlow/index.tsx
+++ b/frontend/client/components/CreateFlow/index.tsx
@@ -138,26 +138,6 @@ class CreateFlow extends React.Component<Props, State> {
   private debouncedUpdateForm: (form: Partial<ProposalDraft>) => void;
   private pollInterval: ReturnType<typeof setInterval> | undefined;
 
-  private pollForTeamChanges = async () => {
-    const { form } = this.props;
-
-    if (this.state.isPolling) return;
-    if (form) {
-      this.setState({ isPolling: true });
-      try {
-        const {
-          data: { invites, team },
-        } = await getProposalInvites(form.proposalId);
-
-        if (!isEqual(form.invites, invites) || !isEqual(form.team, team)) {
-          this.updateForm({ invites, team });
-        }
-        // tslint:disable-next-line:no-empty
-      } catch {}
-      this.setState({ isPolling: false });
-    }
-  };
-
   constructor(props: Props) {
     super(props);
     const searchValues = qs.parse(props.location.search);
@@ -395,6 +375,26 @@ class CreateFlow extends React.Component<Props, State> {
         step: CREATE_STEP.REVIEW,
       });
     }, 50);
+  };
+
+  private pollForTeamChanges = async () => {
+    const { form } = this.props;
+
+    if (this.state.isPolling) return;
+    if (form) {
+      this.setState({ isPolling: true });
+      try {
+        const {
+          data: { invites, team },
+        } = await getProposalInvites(form.proposalId);
+
+        if (!isEqual(form.invites, invites) || !isEqual(form.team, team)) {
+          this.updateForm({ invites, team });
+        }
+        // tslint:disable-next-line:no-empty
+      } catch {}
+      this.setState({ isPolling: false });
+    }
   };
 }
 


### PR DESCRIPTION
Introduces polling for team and invite changes while in the create flow. Team and Review pages now update automatically if an invited team member accepts their invitation. 
 
The team page is now using the proposal form prop to display a team/invite, so the caveat here is there's a small delay when adding/removing team invites.